### PR TITLE
Fixed settings schema to properly add the dataproc menu settings.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,7 @@ import { TITLE_LAUNCHER_CATEGORY } from './utils/const';
 import { RuntimeTemplate } from './runtime/runtimeTemplate';
 
 const extension: JupyterFrontEndPlugin<void> = {
-  id: 'cluster',
+  id: 'dataproc_jupyter_plugin:plugin',
   autoStart: true,
   optional: [ILauncher, IMainMenu, ILabShell, INotebookTracker],
   activate: async (
@@ -217,11 +217,6 @@ const extension: JupyterFrontEndPlugin<void> = {
         app.shell.add(widget, 'main');
       }
     });
-    mainMenu.settingsMenu.addGroup([
-      {
-        command: createAuthLoginComponentCommand
-      }
-    ]);
 
     let serverlessIndex = -1;
 


### PR DESCRIPTION
Issue was similar to what was described here:
https://github.com/jupyterlab/jupyterlab/issues/5277 
"In the fileeditor case, as the id is '@jupyterlab/fileeditor-extension:plugin' (see there), the json file must be named plugin.json." 

Since our id was previously 'cluster', the settings schema was not picking it up.

Fix was to update our plugin id to the proper plugin id format (https://jupyterlab.readthedocs.io/en/stable/extension/extension_dev.html#application-plugins) and use :plugin as the subid.

Also removed previous attempted fix to add the settings option to the menu dynamically.