### PR TITLE
Add authenticated fetch to some components

### DIFF
--- a/src/batches/createBatch.tsx
+++ b/src/batches/createBatch.tsx
@@ -665,7 +665,7 @@ function CreateBatch({
     setIsLoadingRegion(true);
     const credentials = await authApi();
     if (credentials) {
-      fetch(`${REGION_URL}${projectId}/regions`, {
+      fetch(`${REGION_URL}/${projectId}/regions`, {
         headers: {
           'Content-Type': API_HEADER_CONTENT_TYPE,
           Authorization: API_HEADER_BEARER + credentials.access_token

--- a/src/cluster/cluster.tsx
+++ b/src/cluster/cluster.tsx
@@ -112,15 +112,20 @@ const ClusterComponent = (): React.JSX.Element => {
   ) => {
     const pageToken = nextPageToken ?? '';
 
-    const queryParams = new URLSearchParams();
-    queryParams.append('pageSize', '50');
-    queryParams.append('pageToken', pageToken);
-
     try {
       const projectId = await getProjectId();
       setProjectId(projectId);
 
-      const response = await authenticatedFetch('clusters', HTTP_METHOD.GET, queryParams);
+      const queryParams = new URLSearchParams();
+      queryParams.append('pageSize', '50');
+      queryParams.append('pageToken', pageToken);
+
+      const response = await authenticatedFetch({
+        uri: 'clusters',
+        regionIdentifier: 'regions',
+        method: HTTP_METHOD.GET,
+        queryParams: queryParams
+      });
       const formattedResponse = await response.json();
       let transformClusterListData = [];
       if (formattedResponse && formattedResponse.clusters) {
@@ -178,7 +183,11 @@ const ClusterComponent = (): React.JSX.Element => {
 
   const statusApi = async (selectedCluster: string) => {
     try {
-      const response = await authenticatedFetch(`clusters/${selectedCluster}`, HTTP_METHOD.GET);
+      const response = await authenticatedFetch({
+        uri: `clusters/${selectedCluster}`,
+        method: HTTP_METHOD.GET,
+        regionIdentifier: 'regions'
+      });
       const formattedResponse = await response.json();
 
       if (formattedResponse.status.state === ClusterStatus.STATUS_STOPPED) {
@@ -196,7 +205,11 @@ const ClusterComponent = (): React.JSX.Element => {
     setRestartEnabled(true);
 
     try {
-      const response = await authenticatedFetch(`clusters/${selectedCluster}:stop`, HTTP_METHOD.POST);
+      const response = await authenticatedFetch({
+        uri: `clusters/${selectedCluster}:stop`,
+        method: HTTP_METHOD.POST,
+        regionIdentifier: 'regions'
+      });
       const formattedResponse = await response.json();
       console.log(formattedResponse);
       listClustersAPI();
@@ -208,10 +221,9 @@ const ClusterComponent = (): React.JSX.Element => {
       listClustersAPI();
 
       setRestartEnabled(false);
-    }
-    catch(error) {
+    } catch (error) {
       console.error('Error restarting cluster', error);
-          toast.error(`Failed to restart the cluster ${selectedCluster}`);
+      toast.error(`Failed to restart the cluster ${selectedCluster}`);
     }
   };
 

--- a/src/runtime/createRunTime.tsx
+++ b/src/runtime/createRunTime.tsx
@@ -26,6 +26,7 @@ import {
   BASE_URL,
   BASE_URL_META,
   BASE_URL_NETWORKS,
+  HTTP_METHOD,
   PROJECT_LIST_URL,
   REGION_URL,
   STATUS_RUNNING,
@@ -34,7 +35,7 @@ import {
 import TagsInput from 'react-tagsinput';
 import 'react-tagsinput/react-tagsinput.css';
 import LabelProperties from '../jobs/labelProperties';
-import { authApi } from '../utils/utils';
+import { authApi, authenticatedFetch } from '../utils/utils';
 import { ClipLoader } from 'react-spinners';
 import ErrorPopup from '../utils/errorPopup';
 import errorIcon from '../../style/icons/error_icon.svg';
@@ -137,7 +138,7 @@ function CreateRunTime({
       { key: 'm', value: 'm', text: 'min' },
       { key: 's', value: 's', text: 'sec' }
     ];
-   
+
     setTimeList(timeData);
     updateLogic();
     projectListAPI();
@@ -188,6 +189,7 @@ function CreateRunTime({
         });
     }
   };
+
   const updateLogic = () => {
     if (selectedRuntimeClone !== undefined) {
       const {
@@ -201,7 +203,7 @@ function CreateRunTime({
       } = selectedRuntimeClone;
 
       setDisplayNameSelected(jupyterSession.displayName);
-       /*
+      /*
          Extracting runtimeId from name
          Example: "projects/{projectName}/locations/{region}/sessionTemplates/{runtimeid}",
       */
@@ -294,7 +296,7 @@ function CreateRunTime({
         ) {
           const dataprocCluster =
             peripheralsConfig.sparkHistoryServerConfig.dataprocCluster;
-            /*
+          /*
          Extracting clusterName from dataprocCluster
          Example: "projects/{projectName}/locations/{region}/sessionTemplates/{dataprocCluster}",
       */
@@ -306,101 +308,75 @@ function CreateRunTime({
       setCreateTime(new Date().toISOString());
     }
   };
+
   const listClustersAPI = async () => {
-    const credentials = await authApi();
-    if (credentials) {
-      fetch(
-        `${BASE_URL}/projects/${credentials.project_id}/regions/${credentials.region_id}/clusters?pageSize=100`,
-        {
-          headers: {
-            'Content-Type': API_HEADER_CONTENT_TYPE,
-            Authorization: API_HEADER_BEARER + credentials.access_token
+    try {
+      const queryParams = new URLSearchParams({ pageSize: '100' });
+      const response = await authenticatedFetch({
+        uri: 'clusters',
+        method: HTTP_METHOD.GET,
+        regionIdentifier: 'regions',
+        queryParams: queryParams
+      });
+      const formattedResponse: { clusters: Cluster[] } = await response.json();
+      let transformClusterListData = [];
+
+      transformClusterListData = formattedResponse.clusters.filter(
+        (data: Cluster) => {
+          if (data.status.state === STATUS_RUNNING) {
+            return {
+              clusterName: data.clusterName
+            };
           }
         }
-      )
-        .then((response: Response) => {
-          response
-            .json()
-            .then((responseResult: { clusters: Cluster[] }) => {
-              let transformClusterListData = [];
+      );
 
-              transformClusterListData = responseResult.clusters.filter(
-                (data: Cluster) => {
-                  if (data.status.state === STATUS_RUNNING) {
-                    return {
-                      clusterName: data.clusterName
-                    };
-                  }
-                }
-              );
-
-              const keyLabelStructure = transformClusterListData.map(obj => ({
-                key: obj.clusterName,
-                value: obj.clusterName,
-                text: obj.clusterName
-              }));
-              setClustersList(keyLabelStructure);
-            })
-            .catch((e: Error) => {
-              console.log(e);
-            });
-        })
-        .catch((err: Error) => {
-          console.error('Error listing clusters', err);
-        });
+      const keyLabelStructure = transformClusterListData.map(obj => ({
+        key: obj.clusterName,
+        value: obj.clusterName,
+        text: obj.clusterName
+      }));
+      setClustersList(keyLabelStructure);
+    } catch (error) {
+      console.error('Error listing clusters', error);
     }
   };
+
   const listNetworksAPI = async () => {
-    const credentials = await authApi();
-    if (credentials) {
-      fetch(
-        `${BASE_URL_NETWORKS}/projects/${credentials.project_id}/global/networks`,
-        {
-          headers: {
-            'Content-Type': API_HEADER_CONTENT_TYPE,
-            Authorization: API_HEADER_BEARER + credentials.access_token
-          }
-        }
-      )
-        .then((response: Response) => {
-          response
-            .json()
-            .then((responseResult: { items: Network[] }) => {
-              let transformedNetworkList = [];
-              /*
-         Extracting network from items
-         Example: "https://www.googleapis.com/compute/v1/projects/{projectName}/global/networks/",
-      */
+    try {
+      const response = await authenticatedFetch({
+        baseUrl: BASE_URL_NETWORKS,
+        uri: 'networks',
+        method: HTTP_METHOD.GET,
+        regionIdentifier: 'global'
+      });
+      const formattedResponse: { items: Network[] } = await response.json();
+      let transformedNetworkList = [];
+      /*
+ Extracting network from items
+ Example: "https://www.googleapis.com/compute/v1/projects/{projectName}/global/networks/",
+*/
 
-              transformedNetworkList = responseResult.items.map(
-                (data: Network) => {
-                  return {
-                    network: data.selfLink.split('/')[9]
-                  };
-                }
-              );
-              const keyLabelStructureNetwork = transformedNetworkList.map(
-                obj => ({
-                  key: obj.network,
-                  value: obj.network,
-                  text: obj.network
-                })
-              );
-              setNetworklist(keyLabelStructureNetwork);
-            })
-
-            .catch((e: Error) => {
-              console.log(e);
-            });
-        })
-        .catch((err: Error) => {
-          console.error('Error listing Networks', err);
-        });
+      transformedNetworkList = formattedResponse.items.map((data: Network) => {
+        return {
+          network: data.selfLink.split('/')[9]
+        };
+      });
+      const keyLabelStructureNetwork = transformedNetworkList.map(obj => ({
+        key: obj.network,
+        value: obj.network,
+        text: obj.network
+      }));
+      setNetworklist(keyLabelStructureNetwork);
+    } catch (error) {
+      console.error('Error listing Networks', error);
     }
   };
+
   type SubnetworkData = {
     subnetworks: string;
   };
+
   const listSubNetworksAPI = async (subnetwork: string) => {
     const credentials = await authApi();
     if (credentials) {
@@ -501,41 +477,33 @@ function CreateRunTime({
         });
     }
   };
+
   const projectListAPI = async () => {
-    const credentials = await authApi();
-    if (credentials) {
-      fetch(PROJECT_LIST_URL, {
-        method: 'GET',
-        headers: {
-          'Content-Type': API_HEADER_CONTENT_TYPE,
-          Authorization: API_HEADER_BEARER + credentials.access_token
+    try {
+      const response = await authenticatedFetch({
+        baseUrl: PROJECT_LIST_URL,
+        uri: '',
+        method: HTTP_METHOD.GET
+      });
+      const formattedResponse: { projects: Project[] } = await response.json();
+
+      let transformedProjectList = [];
+      transformedProjectList = formattedResponse.projects.map(
+        (data: Project) => {
+          return {
+            projectId: data.projectId
+          };
         }
-      })
-        .then((response: Response) => {
-          response
-            .json()
-            .then((responseResult: { projects: Project[] }) => {
-              let transformedProjectList = [];
-              transformedProjectList = responseResult.projects.map(
-                (data: Project) => {
-                  return {
-                    projectId: data.projectId
-                  };
-                }
-              );
-              const keyLabelStructure = transformedProjectList.map(obj => ({
-                key: obj.projectId,
-                value: obj.projectId,
-                text: obj.projectId
-              }));
-              const noneOption = { key: 'None', value: 'None', text: 'None' };
-              setProjectList([noneOption, ...keyLabelStructure]);
-            })
-            .catch((e: Error) => console.log(e));
-        })
-        .catch((err: Error) => {
-          console.error('Error fetching project list', err);
-        });
+      );
+      const keyLabelStructure = transformedProjectList.map(obj => ({
+        key: obj.projectId,
+        value: obj.projectId,
+        text: obj.projectId
+      }));
+      const noneOption = { key: 'None', value: 'None', text: 'None' };
+      setProjectList([noneOption, ...keyLabelStructure]);
+    } catch (error) {
+      console.error('Error fetching project list', error);
     }
   };
 
@@ -547,7 +515,7 @@ function CreateRunTime({
     setIsLoadingRegion(true);
     const credentials = await authApi();
     if (credentials) {
-      fetch(`${REGION_URL}${projectId}/regions`, {
+      fetch(`${REGION_URL}/${projectId}/regions`, {
         headers: {
           'Content-Type': API_HEADER_CONTENT_TYPE,
           Authorization: API_HEADER_BEARER + credentials.access_token
@@ -678,11 +646,6 @@ function CreateRunTime({
   };
   const handleCancelButton = () => {
     setOpenCreateTemplate(false);
-    // const content = new AuthLogin();
-    // const widget = new MainAreaWidget<AuthLogin>({ content });
-    // widget.title.label = 'Config Setup';
-    // //widget.title.icon = iconCluster;
-    // app.shell.add(widget, 'main');
   };
 
   const handleClusterSelected = (event: any, data: any) => {

--- a/src/runtime/listRuntimeTemplates.tsx
+++ b/src/runtime/listRuntimeTemplates.tsx
@@ -23,12 +23,14 @@ import deleteIcon from '../../style/icons/delete_icon.svg';
 import { ClipLoader } from 'react-spinners';
 import GlobalFilter from '../utils/globalFilter';
 import {
-  API_HEADER_BEARER,
-  API_HEADER_CONTENT_TYPE,
-  BASE_URL
+  HTTP_METHOD
 } from '../utils/const';
 import TableData from '../utils/tableData';
-import { ICellProps, authApi, jobTimeFormat } from '../utils/utils';
+import {
+  ICellProps,
+  authenticatedFetch,
+  jobTimeFormat
+} from '../utils/utils';
 import DeletePopup from '../utils/deletePopup';
 import { toast, ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
@@ -148,93 +150,78 @@ function ListRuntimeTemplates({
     nextPageToken?: string,
     previousRuntimeTemplatesList?: object
   ) => {
-    const credentials = await authApi();
-    const pageToken = nextPageToken ?? '';
-    if (credentials) {
-      fetch(
-        `${BASE_URL}/projects/${credentials.project_id}/locations/${credentials.region_id}/sessionTemplates?pageSize=50&pageToken=${pageToken}`,
-        {
-          headers: {
-            'Content-Type': API_HEADER_CONTENT_TYPE,
-            Authorization: API_HEADER_BEARER + credentials.access_token
+    try {
+      const pageToken = nextPageToken ?? '';
+      const queryParams = new URLSearchParams({
+        pageSize: '50',
+        pageToken: pageToken
+      });
+
+      const response = await authenticatedFetch({
+        uri: 'sessionTemplates',
+        method: HTTP_METHOD.GET,
+        regionIdentifier: 'locations',
+        queryParams: queryParams
+      });
+      const formattedResponse: SessionTemplateRoot = await response.json();
+      let transformRuntimeTemplatesListData: SessionTemplateDisplay[] = [];
+      if (formattedResponse && formattedResponse.sessionTemplates) {
+        setRunTimeTemplateAllList(formattedResponse.sessionTemplates);
+        let runtimeTemplatesListNew = formattedResponse.sessionTemplates;
+        runtimeTemplatesListNew.sort(
+          (a: { updateTime: string }, b: { updateTime: string }) => {
+            const dateA = new Date(a.updateTime);
+            const dateB = new Date(b.updateTime);
+            return Number(dateB) - Number(dateA);
           }
-        }
-      )
-        .then((response: Response) => {
-          response
-            .json()
-            .then((responseResult: SessionTemplateRoot) => {
-              let transformRuntimeTemplatesListData: SessionTemplateDisplay[] =
-                [];
-              if (responseResult && responseResult.sessionTemplates) {
-                setRunTimeTemplateAllList(responseResult.sessionTemplates);
-                let runtimeTemplatesListNew = responseResult.sessionTemplates;
-                runtimeTemplatesListNew.sort(
-                  (a: { updateTime: string }, b: { updateTime: string }) => {
-                    const dateA = new Date(a.updateTime);
-                    const dateB = new Date(b.updateTime);
-                    return Number(dateB) - Number(dateA);
-                  }
-                );
-                transformRuntimeTemplatesListData = runtimeTemplatesListNew.map(
-                  (data: SessionTemplate) => {
-                    const startTimeDisplay = data.updateTime
-                      ? jobTimeFormat(data.updateTime)
-                      : '';
+        );
+        transformRuntimeTemplatesListData = runtimeTemplatesListNew.map(
+          (data: SessionTemplate) => {
+            const startTimeDisplay = data.updateTime
+              ? jobTimeFormat(data.updateTime)
+              : '';
 
-                    let displayName = '';
+            let displayName = '';
 
-                    if (
-                      data.jupyterSession &&
-                      data.jupyterSession.displayName
-                    ) {
-                      displayName = data.jupyterSession.displayName;
-                    }
-                    /*
-         Extracting runtimeId from name
-         Example: "projects/{projectName}/locations/{region}/sessionTemplates/{runtimeid}",
-      */
+            if (data.jupyterSession && data.jupyterSession.displayName) {
+              displayName = data.jupyterSession.displayName;
+            }
 
-                    return {
-                      name: displayName,
-                      owner: data.creator,
-                      description: data.description,
-                      lastModified: startTimeDisplay,
-                      actions: renderActions(data),
-                      id: data.name.split('/')[5]
-                    };
-                  }
-                );
-              }
+            // Extracting runtimeId from name
+            // Example: "projects/{projectName}/locations/{region}/sessionTemplates/{runtimeid}",
 
-              const existingRuntimeTemplatesData =
-                previousRuntimeTemplatesList ?? [];
-              //setStateAction never type issue
-              let allRuntimeTemplatesData: SessionTemplateDisplay[] = [
-                ...(existingRuntimeTemplatesData as []),
-                ...transformRuntimeTemplatesListData
-              ];
+            return {
+              name: displayName,
+              owner: data.creator,
+              description: data.description,
+              lastModified: startTimeDisplay,
+              actions: renderActions(data),
+              id: data.name.split('/')[5]
+            };
+          }
+        );
+      }
 
-              if (responseResult.nextPageToken) {
-                listRuntimeTemplatesAPI(
-                  responseResult.nextPageToken,
-                  allRuntimeTemplatesData
-                );
-              } else {
-                setRuntimeTemplateslist(allRuntimeTemplatesData);
-                setIsLoading(false);
-              }
-            })
-            .catch((e: Error) => {
-              console.error(e);
-              setIsLoading(false);
-            });
-        })
-        .catch((err: Error) => {
-          setIsLoading(false);
-          console.error('Error listing runtime templates', err);
-          toast.error('Failed to fetch runtime templates');
-        });
+      const existingRuntimeTemplatesData = previousRuntimeTemplatesList ?? [];
+      //setStateAction never type issue
+      let allRuntimeTemplatesData: SessionTemplateDisplay[] = [
+        ...(existingRuntimeTemplatesData as []),
+        ...transformRuntimeTemplatesListData
+      ];
+
+      if (formattedResponse.nextPageToken) {
+        listRuntimeTemplatesAPI(
+          formattedResponse.nextPageToken,
+          allRuntimeTemplatesData
+        );
+      } else {
+        setRuntimeTemplateslist(allRuntimeTemplatesData);
+        setIsLoading(false);
+      }
+    } catch (error) {
+      setIsLoading(false);
+      console.error('Error listing runtime templates', error);
+      toast.error('Failed to fetch runtime templates');
     }
   };
 

--- a/src/sessions/listSessions.tsx
+++ b/src/sessions/listSessions.tsx
@@ -15,22 +15,21 @@
  * limitations under the License.
  */
 
-import React, { useState, useEffect, useRef } from 'react';
-import { useTable, useGlobalFilter, usePagination } from 'react-table';
 import { LabIcon } from '@jupyterlab/ui-components';
-import filterIcon from '../../style/icons/filter_icon.svg';
-import SucceededIcon from '../../style/icons/succeeded_icon.svg';
-import clusterErrorIcon from '../../style/icons/cluster_error_icon.svg';
-import stopIcon from '../../style/icons/stop_icon.svg';
-import stopDisableIcon from '../../style/icons/stop_disable_icon.svg';
-import deleteIcon from '../../style/icons/delete_icon.svg';
+import React, { useEffect, useRef, useState } from 'react';
 import { ClipLoader } from 'react-spinners';
-import GlobalFilter from '../utils/globalFilter';
+import { useGlobalFilter, usePagination, useTable } from 'react-table';
+import { ToastContainer, toast } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
+import clusterErrorIcon from '../../style/icons/cluster_error_icon.svg';
+import deleteIcon from '../../style/icons/delete_icon.svg';
+import filterIcon from '../../style/icons/filter_icon.svg';
+import stopDisableIcon from '../../style/icons/stop_disable_icon.svg';
+import stopIcon from '../../style/icons/stop_icon.svg';
+import SucceededIcon from '../../style/icons/succeeded_icon.svg';
 import {
-  API_HEADER_BEARER,
-  API_HEADER_CONTENT_TYPE,
-  BASE_URL,
   ClusterStatus,
+  HTTP_METHOD,
   STATUS_ACTIVE,
   STATUS_CREATING,
   STATUS_DELETING,
@@ -40,20 +39,19 @@ import {
   STATUS_TERMINATED,
   STATUS_TERMINATING
 } from '../utils/const';
+import DeletePopup from '../utils/deletePopup';
+import GlobalFilter from '../utils/globalFilter';
+import { PaginationView } from '../utils/paginationView';
+import PollingTimer from '../utils/pollingTimer';
+import { deleteSessionAPI, terminateSessionAPI } from '../utils/sessionService';
 import TableData from '../utils/tableData';
 import {
   ICellProps,
-  authApi,
+  authenticatedFetch,
   elapsedTime,
   jobTimeFormat
 } from '../utils/utils';
 import SessionDetails from './sessionDetails';
-import DeletePopup from '../utils/deletePopup';
-import { toast, ToastContainer } from 'react-toastify';
-import 'react-toastify/dist/ReactToastify.css';
-import { deleteSessionAPI, terminateSessionAPI } from '../utils/sessionService';
-import { PaginationView } from '../utils/paginationView';
-import PollingTimer from '../utils/pollingTimer';
 
 const iconFilter = new LabIcon({
   name: 'launcher:filter-icon',
@@ -80,7 +78,6 @@ const iconDelete = new LabIcon({
   name: 'launcher:delete-icon',
   svgstr: deleteIcon
 });
-
 
 function ListSessions() {
   const [sessionsList, setSessionsList] = useState([]);
@@ -144,82 +141,69 @@ function ListSessions() {
     nextPageToken?: string,
     previousSessionsList?: object
   ) => {
-    const credentials = await authApi();
-    const pageToken = nextPageToken ?? '';
-    if (credentials) {
-      fetch(
-        `${BASE_URL}/projects/${credentials.project_id}/locations/${credentials.region_id}/sessions?pageSize=50&pageToken=${pageToken}`,
-        {
-          headers: {
-            'Content-Type': API_HEADER_CONTENT_TYPE,
-            Authorization: API_HEADER_BEARER + credentials.access_token
+    try {
+      const pageToken = nextPageToken ?? '';
+      const queryParams = new URLSearchParams();
+      queryParams.append('pageSize', '50');
+      queryParams.append('pageToken', pageToken);
+
+      const response = await authenticatedFetch({
+        uri: 'sessions',
+        method: HTTP_METHOD.GET,
+        regionIdentifier: 'locations',
+        queryParams: queryParams
+      });
+      const formattedResponse = await response.json();
+      let transformSessionListData = [];
+      if (formattedResponse && formattedResponse.sessions) {
+        let sessionsListNew = formattedResponse.sessions;
+        sessionsListNew.sort(
+          (a: { createTime: string }, b: { createTime: string }) => {
+            const dateA = new Date(a.createTime);
+            const dateB = new Date(b.createTime);
+            return Number(dateB) - Number(dateA);
           }
-        }
-      )
-        .then((response: Response) => {
-          response
-            .json()
-            .then((responseResult: any) => {
-              let transformSessionListData = [];
-              if (responseResult && responseResult.sessions) {
-                let sessionsListNew = responseResult.sessions;
-                sessionsListNew.sort(
-                  (a: { createTime: string }, b: { createTime: string }) => {
-                    const dateA = new Date(a.createTime);
-                    const dateB = new Date(b.createTime);
-                    return Number(dateB) - Number(dateA);
-                  }
-                );
-                transformSessionListData = sessionsListNew.map((data: any) => {
-                  const startTimeDisplay = jobTimeFormat(data.createTime);
-                  const startTime = new Date(data.createTime);
-                  let elapsedTimeString = '';
-                  if (
-                    data.state === STATUS_TERMINATED ||
-                    data.state === STATUS_FAIL
-                  ) {
-                    elapsedTimeString = elapsedTime(data.stateTime, startTime);
-                  }
-                  /*
-                    Extracting sessionID, location from sessionInfo.name
-                    Example: "projects/{project}/locations/{location}/sessions/{sessionID}"
-                  */
-                  return {
-                    sessionID: data.name.split('/')[5],
-                    status: data.state,
-                    location: data.name.split('/')[3],
-                    creator: data.creator,
-                    creationTime: startTimeDisplay,
-                    elapsedTime: elapsedTimeString,
-                    actions: renderActions(data)
-                  };
-                });
-              }
+        );
+        transformSessionListData = sessionsListNew.map((data: any) => {
+          const startTimeDisplay = jobTimeFormat(data.createTime);
+          const startTime = new Date(data.createTime);
+          let elapsedTimeString = '';
+          if (data.state === STATUS_TERMINATED || data.state === STATUS_FAIL) {
+            elapsedTimeString = elapsedTime(data.stateTime, startTime);
+          }
 
-              const existingSessionsData = previousSessionsList ?? [];
-              //setStateAction never type issue
-              let allSessionsData: any = [
-                ...(existingSessionsData as []),
-                ...transformSessionListData
-              ];
+          // Extracting sessionID, location from sessionInfo.name
+          // Example: "projects/{project}/locations/{location}/sessions/{sessionID}"
 
-              if (responseResult.nextPageToken) {
-                listSessionsAPI(responseResult.nextPageToken, allSessionsData);
-              } else {
-                setSessionsList(allSessionsData);
-                setIsLoading(false);
-              }
-            })
-            .catch((e: Error) => {
-              console.log(e);
-              setIsLoading(false);
-            });
-        })
-        .catch((err: Error) => {
-          setIsLoading(false);
-          console.error('Error listing Sessions', err);
-          toast.error('Failed to fetch sessions');
+          return {
+            sessionID: data.name.split('/')[5],
+            status: data.state,
+            location: data.name.split('/')[3],
+            creator: data.creator,
+            creationTime: startTimeDisplay,
+            elapsedTime: elapsedTimeString,
+            actions: renderActions(data)
+          };
         });
+      }
+
+      const existingSessionsData = previousSessionsList ?? [];
+      // setStateAction never type issue
+      let allSessionsData: any = [
+        ...(existingSessionsData as []),
+        ...transformSessionListData
+      ];
+
+      if (formattedResponse.nextPageToken) {
+        listSessionsAPI(formattedResponse.nextPageToken, allSessionsData);
+      } else {
+        setSessionsList(allSessionsData);
+        setIsLoading(false);
+      }
+    } catch (error) {
+      setIsLoading(false);
+      console.error('Error listing Sessions', error);
+      toast.error('Failed to fetch sessions');
     }
   };
 

--- a/src/sessions/sessionDetails.tsx
+++ b/src/sessions/sessionDetails.tsx
@@ -23,9 +23,7 @@ import StopClusterDisableIcon from '../../style/icons/stop_cluster_disable_icon.
 import SucceededIcon from '../../style/icons/succeeded_icon.svg';
 import clusterErrorIcon from '../../style/icons/cluster_error_icon.svg';
 import {
-  API_HEADER_BEARER,
-  API_HEADER_CONTENT_TYPE,
-  BASE_URL,
+  HTTP_METHOD,
   NETWORK_KEY,
   NETWORK_LABEL,
   SERVICE_ACCOUNT_KEY,
@@ -43,7 +41,11 @@ import {
   SUBNETWORK_KEY,
   SUBNETWORK_LABEL
 } from '../utils/const';
-import { authApi, elapsedTime, jobTimeFormat } from '../utils/utils';
+import {
+  authenticatedFetch,
+  elapsedTime,
+  jobTimeFormat
+} from '../utils/utils';
 import ClipLoader from 'react-spinners/ClipLoader';
 import ViewLogs from '../utils/viewLogs';
 import { toast, ToastContainer } from 'react-toastify';
@@ -116,44 +118,27 @@ function SessionDetails({
     setDetailedSessionView(false);
   };
   const getSessionDetails = async () => {
-    const credentials = await authApi();
-    if (credentials) {
-      fetch(
-        `${BASE_URL}/projects/${credentials.project_id}/locations/${credentials.region_id}/sessions/${sessionSelected}`,
-        {
-          method: 'GET',
-          headers: {
-            'Content-Type': API_HEADER_CONTENT_TYPE,
-            Authorization: API_HEADER_BEARER + credentials.access_token
-          }
+    try {
+      const response = await authenticatedFetch({
+        uri: `sessions/${sessionSelected}`,
+        method: HTTP_METHOD.GET,
+        regionIdentifier: 'locations'
+      });
+
+      const formattedResponse = await response.json();
+      setSessionInfo(formattedResponse);
+      const labelValue: string[] = [];
+      if (formattedResponse.labels) {
+        for (const [key, value] of Object.entries(formattedResponse.labels)) {
+          labelValue.push(`${key}:${value}`);
         }
-      )
-        .then((response: Response) => {
-          response
-            .json()
-            .then((responseResult: any) => {
-              setSessionInfo(responseResult);
-              const labelValue: string[] = [];
-              if (responseResult.labels) {
-                for (const [key, value] of Object.entries(
-                  responseResult.labels
-                )) {
-                  labelValue.push(`${key}:${value}`);
-                }
-              }
-              setLabelDetail(labelValue);
-              setIsLoading(false);
-            })
-            .catch((e: Error) => {
-              console.log(e);
-              setIsLoading(false);
-            });
-        })
-        .catch((err: Error) => {
-          setIsLoading(false);
-          console.error('Error loading session details', err);
-          toast.error(`Failed to fetch session details ${sessionSelected}`);
-        });
+      }
+      setLabelDetail(labelValue);
+      setIsLoading(false);
+    } catch (error) {
+      setIsLoading(false);
+      console.error('Error loading session details', error);
+      toast.error(`Failed to fetch session details ${sessionSelected}`);
     }
   };
 

--- a/src/utils/const.ts
+++ b/src/utils/const.ts
@@ -66,7 +66,7 @@ export const SPARK_HISTORY_SERVER_KEY = 'sparkHistoryServerConfig';
 export const PROJECT_LIST_URL =
   'https://cloudresourcemanager.googleapis.com/v1/projects';
 export const USER_INFO_URL = 'https://www.googleapis.com/oauth2/v2/userinfo';
-export const REGION_URL = 'https://compute.googleapis.com/compute/v1/projects/';
+export const REGION_URL = 'https://compute.googleapis.com/compute/v1/projects';
 export const LOGIN_STATE = '1';
 export const QUERY_TABLE = 'system=dataproc_metastore AND type=TABLE parent=';
 export const QUERY_DATABASE =

--- a/src/utils/regionService.tsx
+++ b/src/utils/regionService.tsx
@@ -32,7 +32,7 @@ const regionListAPI = async (projectId: string) => {
   if (!credentials) {
     return [];
   }
-  const resp = await fetch(`${REGION_URL}${projectId}/regions`, {
+  const resp = await fetch(`${REGION_URL}/${projectId}/regions`, {
     method: 'GET',
     headers: {
       'Content-Type': API_HEADER_CONTENT_TYPE,

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -41,6 +41,7 @@ import {
   STATUS_STARTING,
   STATUS_SUCCESS
 } from './const';
+
 export interface IAuthCredentials {
   access_token?: string;
   project_id?: string;
@@ -71,18 +72,23 @@ export const authApi = async (): Promise<IAuthCredentials | undefined> => {
 
 /**
  * Wraps a fetch call with initial authentication to pass credentials to the request
- * 
+ *
  * @param uri the endpoint to call e.g. "/clusters"
+ * @param method the HTTP method used for the request
+ * @param regionIdentifier option param to define what region identifier (location, region) to use
  * @param queryParams
  * @returns a promise of the fetch result
  */
-export const authenticatedFetch = async (
-  uri: string,
-  method: HTTP_METHOD,
-  queryParams?: URLSearchParams
-) => {
+export const authenticatedFetch = async (config: {
+  baseUrl?: string;
+  uri: string;
+  method: HTTP_METHOD;
+  regionIdentifier?: 'regions' | 'locations' | 'global';
+  queryParams?: URLSearchParams;
+}) => {
+  const { baseUrl, uri, method, regionIdentifier, queryParams } = config;
   const credentials = await authApi();
-  // If there is an issue with getting credentials, there is no point continuing the request. 
+  // If there is an issue with getting credentials, there is no point continuing the request.
   if (!credentials) {
     throw new Error('Error during authentication');
   }
@@ -96,22 +102,42 @@ export const authenticatedFetch = async (
   };
 
   const serializedQueryParams = queryParams?.toString();
-  let requestUrl = `${BASE_URL}/projects/${credentials.project_id}/regions/${credentials.region_id}/${uri}`;
-  // if serializedQueryParams is defined and non empty, then add it(them) to the request url, otherwise just use the request url
-  requestUrl = serializedQueryParams ? requestUrl + `?${serializedQueryParams}` : requestUrl;
-  
+  const base = baseUrl ?? BASE_URL;
+  let requestUrl = `${base}/projects/${credentials.project_id}`;
+
+  if (regionIdentifier) {
+    switch (regionIdentifier) {
+      case 'regions':
+        requestUrl = `${requestUrl}/regions/${credentials.region_id}`;
+        break;
+      case 'locations':
+        requestUrl = `${requestUrl}/locations/${credentials.region_id}`;
+        break;
+      case 'global':
+        requestUrl = `${requestUrl}/global`;
+        break;
+      default:
+        assumeNeverHit(regionIdentifier);
+    }
+  }
+
+  requestUrl = `${requestUrl}/${uri}`;
+  if (serializedQueryParams) {
+    requestUrl = `${requestUrl}?${serializedQueryParams}`;
+  }
+
   return fetch(requestUrl, requestOptions);
 };
 
 /**
  * Makes a request to the auth api to get the current project ID
- * 
+ *
  * @returns the project id if it exists otherwise an empty string
  */
 export const getProjectId = async (): Promise<string> => {
   const credentials = await authApi();
   return credentials?.project_id ?? '';
-}
+};
 
 export const jobTimeFormat = (startTime: string) => {
   const date = new Date(startTime);
@@ -368,3 +394,5 @@ export const batchDetailsOptionalDisplay = (data: string) => {
       return detailsPageOptionalDisplay(data);
   }
 };
+
+export function assumeNeverHit(_: never): void {}


### PR DESCRIPTION
Does not replace all instances of `authAPI` to use `authenticatedFetch` because either those use credential information elsewhere in their data transformation logic, or the requests don't fit the pattern handled by `authenticatedFetch`. 