### PR TITLE
revert projectListAPI use of authenticatedFetch

### DIFF
--- a/src/runtime/createRunTime.tsx
+++ b/src/runtime/createRunTime.tsx
@@ -480,10 +480,16 @@ function CreateRunTime({
 
   const projectListAPI = async () => {
     try {
-      const response = await authenticatedFetch({
-        baseUrl: PROJECT_LIST_URL,
-        uri: '',
-        method: HTTP_METHOD.GET
+      const credentials = await authApi();
+      if (!credentials) {
+        return;
+      }
+      const response = await fetch(PROJECT_LIST_URL, {
+        method: 'GET',
+        headers: {
+          'Content-Type': API_HEADER_CONTENT_TYPE,
+          Authorization: API_HEADER_BEARER + credentials.access_token
+        }
       });
       const formattedResponse: { projects: Project[] } = await response.json();
 


### PR DESCRIPTION
Verified that project id selector in metastore picker in createruntime works again.

<img width="950" alt="Screenshot 2023-09-05 at 9 51 07 AM" src="https://github.com/GoogleCloudDataproc/dataproc-jupyter-plugin/assets/9376175/cb874fd3-1ee9-4b50-8f79-5178e82fa8b7">
