### PR TITLE
Increased timeout in kokoro tests.

### DIFF
--- a/kokoro/gcp_ubuntu_docker/continuous.cfg
+++ b/kokoro/gcp_ubuntu_docker/continuous.cfg
@@ -10,6 +10,7 @@ action {
   define_artifacts {
     regex: "github/dataproc-jupyter-plugin/ui-tests/test-results/**"
     regex: "github/dataproc-jupyter-plugin/ui-tests/playwright-report/**"
+    regex: "github/dataproc-jupyter-plugin/dist/**"
     strip_prefix: "github/dataproc-jupyter-plugin/ui-tests/"
   }
 }

--- a/kokoro/gcp_ubuntu_docker/kokoro_build.sh
+++ b/kokoro/gcp_ubuntu_docker/kokoro_build.sh
@@ -26,8 +26,8 @@ gcloud config set compute/region us-central1
 sudo apt-get update
 sudo apt-get --assume-yes install python3 python3-pip nodejs
 
-# Install jupyter lab.
-pip install jupyterlab
+# Install jupyter lab and build.
+pip install jupyterlab build
 
 # Navigate to repo.
 cd "${KOKORO_ARTIFACTS_DIR}/github/dataproc-jupyter-plugin"
@@ -40,7 +40,8 @@ jupyter labextension develop . --overwrite
 jupyter server extension enable dataproc_jupyter_plugin
 # Rebuild extension Typescript source after making changes
 jlpm build
-
+# Aslo build python packages to dist/
+python -m build
 
 # Run Playwright Tests
 cd ./ui-tests

--- a/kokoro/gcp_ubuntu_docker/presubmit.cfg
+++ b/kokoro/gcp_ubuntu_docker/presubmit.cfg
@@ -10,6 +10,7 @@ action {
   define_artifacts {
     regex: "github/dataproc-jupyter-plugin/ui-tests/test-results/**"
     regex: "github/dataproc-jupyter-plugin/ui-tests/playwright-report/**"
+    regex: "github/dataproc-jupyter-plugin/dist/**"
     strip_prefix: "github/dataproc-jupyter-plugin/ui-tests/"
   }
 }

--- a/ui-tests/playwright.config.js
+++ b/ui-tests/playwright.config.js
@@ -32,6 +32,12 @@ module.exports = {
     viewport: {
       width: 1280,
       height: 720
-    }
+    },
+    // Capture screenshot after each test failure.
+    screenshot: 'only-on-failure',
+    // Record trace only when retrying a test for the first time.
+    trace: 'on-first-retry',
+    // Record video only when retrying a test for the first time.
+    video: 'on-first-retry'
   }
 };

--- a/ui-tests/tests/create_and_run_notebook.spec.ts
+++ b/ui-tests/tests/create_and_run_notebook.spec.ts
@@ -38,7 +38,7 @@ test.describe('Create and run notebook', () => {
     // Wait for kernel to be ready (why unknown?  Is this a bug?)
     await page
       .locator('.jp-Notebook-ExecutionIndicator[data-status="unknown"]')
-      .waitFor({ timeout: 5000 });
+      .waitFor({ timeout: 10000 });
 
     await firstCodeBox.click();
     await firstCodeBox.fill("print('test output')");

--- a/ui-tests/tests/settings_menu.spec.ts
+++ b/ui-tests/tests/settings_menu.spec.ts
@@ -15,14 +15,37 @@
  * limitations under the License.
  */
 
-import { test } from '@jupyterlab/galata';
+import { test, expect, galata } from '@jupyterlab/galata';
 
 test.describe('Settings Menu', () => {
-  test('Settings Menu is visible and clickable', async ({ page }) => {
+  test('Can find settings menu', async ({ page }) => {
     await page
       .getByLabel('main', { exact: true })
       .getByText('Settings')
       .click();
     await page.getByText('Cloud Dataproc Settings').click();
+  });
+
+  test('Can change project', async ({ page }) => {
+    await page
+      .getByLabel('main', { exact: true })
+      .getByText('Settings')
+      .click();
+    await page.getByText('Cloud Dataproc Settings').click();
+
+    // Assert clearing the Project ID disables the save button.
+    await page.getByRole('combobox', { name: 'Project ID' }).click();
+    await page.getByRole('button', { name: 'Clear' }).click();
+    await expect(page.getByRole('button', { name: 'Save' })).toBeDisabled();
+
+    // Assert that we can save the project after we fill in project again.
+    await page.getByRole('combobox', { name: 'Project ID' }).click();
+    await page.getByRole('combobox', { name: 'Project ID' }).fill('kokoro');
+    await page.getByRole('option', { name: 'dataproc-kokoro-tests' }).click();
+    await expect(page.getByRole('button', { name: 'Save' })).not.toBeDisabled();
+
+    // Do not actually save. Due to tests running in parallel, changing the project
+    // can cause other tests to fail as their access tokens get revoked from
+    // underneath them.
   });
 });


### PR DESCRIPTION
A few changes:
- Increase the wait for the kernel to be connected from 5 seconds to 10 seconds
- Add a integration test that tests settings functionality (unfortunately actually hitting save causes other concurrent tests to fail so we are not doing that at the moment)
- Also generate build candidates into GCS.