### PR TITLE
Update the dependency on `kernels-mixer` to the latest release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 dependencies = [
     "jupyter_server>=2.0.1,<3",
     "cachetools>=5.0.0",
-    "kernels-mixer",
+    "kernels-mixer>=0.0.4",
 ]
 dynamic = ["version", "description", "authors", "urls", "keywords"]
 


### PR DESCRIPTION
That newest version includes some important bug fixes, so we want to make sure anyone installing the plugin picks it up.