### PR TITLE
Wrap injectToastContainer in a try/catch

### DIFF
--- a/dataproc_jupyter_plugin/__init__.py
+++ b/dataproc_jupyter_plugin/__init__.py
@@ -70,7 +70,7 @@ def _link_jupyter_server_extension(server_app):
 
     plugin_config = DataprocPluginConfig(config=server_app.config)
     if (plugin_config.log_path != ""):
-        file_handler = logging.RotatingFileHandler(plugin_config.log_path, maxBytes= 2 * 1024 * 1024, backupCount=5)
+        file_handler = logging.handlers.RotatingFileHandler(plugin_config.log_path, maxBytes= 2 * 1024 * 1024, backupCount=5)
         file_handler.setFormatter(logging.Formatter('[%(levelname)s %(asctime)s %(name)s] %(message)s'))
         server_app.log.addHandler(file_handler)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dataproc_jupyter_plugin",
-    "version": "0.1.50",
+    "version": "0.1.51",
     "description": "It is a plugin to work with dataproc services in Jupyterlab",
     "keywords": [
         "jupyter",

--- a/src/index.ts
+++ b/src/index.ts
@@ -118,9 +118,13 @@ const extension: JupyterFrontEndPlugin<void> = {
       localStorage.removeItem('notebookValue');
     });
 
-    // React-Toastify needs a ToastContainer to render toasts, since we don't
-    // have a global React Root, lets just inject one in the body.
-    injectToastContainer();
+    try {
+      // React-Toastify needs a ToastContainer to render toasts, since we don't
+      // have a global React Root, lets just inject one in the body.
+      injectToastContainer();
+    } catch (e) {
+      // do nothing
+    }
 
     // START -- Enable Preview Features.
     const settings = await settingRegistry.load(PLUGIN_ID);


### PR DESCRIPTION
Currently react-dom is throwing because we expect "react-dom": "^18.2.0", but what we are getting is react-dom 17.  Since the toastcontainer isn't SUPER critical, wrap it in a try catch to unblock 3.6.6 until we have a better solution.