### PR TITLE
Unpin  the `kernels-mixer` package version used in tests

### DIFF
--- a/kokoro/gcp_ubuntu_docker/kokoro_build.sh
+++ b/kokoro/gcp_ubuntu_docker/kokoro_build.sh
@@ -41,7 +41,6 @@ jlpm build
 python -m build
 
 # install the build
-pip install kernels-mixer==0.0.7
 pip install dist/*.whl
 jupyter server extension enable dataproc_jupyter_plugin
 
@@ -57,7 +56,6 @@ cd "${KOKORO_ARTIFACTS_DIR}/github/dataproc-jupyter-plugin"
 python -m venv version_366
 source version_366/bin/activate
 pip install  --force-reinstall "jupyterlab==3.6.6"
-pip install kernels-mixer==0.0.7
 pip install dist/*.whl
 jupyter server extension enable dataproc_jupyter_plugin
 cd ./ui-tests-3.6.6


### PR DESCRIPTION
This is to test whether or not https://pypi.org/project/kernels-mixer/0.0.9 fixes the test failures