### PR TITLE
Add a handler for getting the Dataproc plugin settings.

### DIFF
--- a/dataproc_jupyter_plugin/__init__.py
+++ b/dataproc_jupyter_plugin/__init__.py
@@ -19,19 +19,8 @@ from kernels_mixer.kernels import MixingMappingKernelManager
 from kernels_mixer.websockets import DelegatingWebsocketConnection
 
 from jupyter_server.services.sessions.sessionmanager import SessionManager
-from traitlets import Unicode
-from traitlets.config import Configurable
 
-
-from .handlers import setup_handlers, update_gateway_client_url
-
-
-class DataprocPluginConfig(Configurable):
-    log_path = Unicode(
-        "",
-        config=True,
-        help="File to log ServerApp and Dataproc Jupyter Plugin events.",
-    )
+from .handlers import setup_handlers, update_gateway_client_url, DataprocPluginConfig
 
 
 def _jupyter_labextension_paths():
@@ -68,7 +57,7 @@ def _link_jupyter_server_extension(server_app):
 
     update_gateway_client_url(c, server_app.log)
 
-    plugin_config = DataprocPluginConfig(config=server_app.config)
+    plugin_config = DataprocPluginConfig.instance(parent=server_app)
     if plugin_config.log_path != "":
         file_handler = logging.handlers.RotatingFileHandler(
             plugin_config.log_path, maxBytes=2 * 1024 * 1024, backupCount=5

--- a/dataproc_jupyter_plugin/tests/test_handlers.py
+++ b/dataproc_jupyter_plugin/tests/test_handlers.py
@@ -15,11 +15,12 @@
 import json
 
 
-async def test_get_example(jp_fetch):
+async def test_get_settings(jp_fetch):
     # When
-    response = await jp_fetch("dataproc-plugin", "get-example")
+    response = await jp_fetch("dataproc-plugin", "settings")
 
     # Then
     assert response.code == 200
     payload = json.loads(response.body)
-    assert payload == {"data": "This is /dataproc-plugin/get-example endpoint!"}
+    assert "enable_bigquery_integration" in payload
+    assert "log_path" in payload

--- a/dataproc_jupyter_plugin/tests/test_handlers.py
+++ b/dataproc_jupyter_plugin/tests/test_handlers.py
@@ -15,12 +15,23 @@
 import json
 
 
-async def test_get_settings(jp_fetch):
-    # When
+async def test_get_default_settings(jp_fetch):
     response = await jp_fetch("dataproc-plugin", "settings")
 
-    # Then
     assert response.code == 200
     payload = json.loads(response.body)
     assert "enable_bigquery_integration" in payload
     assert "log_path" in payload
+    assert payload["enable_bigquery_integration"] is False
+    assert payload["log_path"] is ""
+
+
+async def test_get_modified_settings(jp_fetch, jp_serverapp):
+    jp_serverapp.config.DataprocPluginConfig.enable_bigquery_integration = True
+    response = await jp_fetch("dataproc-plugin", "settings")
+    assert response.code == 200
+    payload = json.loads(response.body)
+    assert "enable_bigquery_integration" in payload
+    assert "log_path" in payload
+    assert payload["enable_bigquery_integration"] is True
+    assert payload["log_path"] is ""


### PR DESCRIPTION
As part of this, I've also done some cleanups in the `handlers.py` code:

1. Put all of the import statements into a consistent order.
2. Reduce the amount of boilerplate/duplicated code in the `setup_handlers` method.
3. Renamed `RouteHandler` to the more meaningful `CredentialsHandler` to match what it does.