### PR TITLE
Fix the pytest tests

### DIFF
--- a/dataproc_jupyter_plugin/controllers/airflow.py
+++ b/dataproc_jupyter_plugin/controllers/airflow.py
@@ -14,6 +14,7 @@
 
 import json
 
+import aiohttp
 import tornado
 from jupyter_server.base.handlers import APIHandler
 
@@ -25,9 +26,12 @@ class DagListController(APIHandler):
     @tornado.web.authenticated
     async def get(self):
         try:
-            client = airflow.Client(await credentials.get_cached(), self.log)
             composer_name = self.get_argument("composer")
-            dag_list = await client.list_jobs(composer_name)
+            async with aiohttp.ClientSession() as client_session:
+                client = airflow.Client(
+                    await credentials.get_cached(), self.log, client_session
+                )
+                dag_list = await client.list_jobs(composer_name)
             self.finish(json.dumps(dag_list))
         except Exception as e:
             self.log.exception("Error fetching cluster list")
@@ -38,11 +42,14 @@ class DagDeleteController(APIHandler):
     @tornado.web.authenticated
     async def get(self):
         try:
-            client = airflow.Client(await credentials.get_cached(), self.log)
             composer = self.get_argument("composer")
             dag_id = self.get_argument("dag_id")
             from_page = self.get_argument("from_page", default=None)
-            delete_response = await client.delete_job(composer, dag_id, from_page)
+            async with aiohttp.ClientSession() as client_session:
+                client = airflow.Client(
+                    await credentials.get_cached(), self.log, client_session
+                )
+                delete_response = await client.delete_job(composer, dag_id, from_page)
             if delete_response == 0:
                 self.finish(json.dumps({"status": delete_response}))
             else:
@@ -57,11 +64,14 @@ class DagUpdateController(APIHandler):
     @tornado.web.authenticated
     async def get(self):
         try:
-            client = airflow.Client(await credentials.get_cached(), self.log)
             composer = self.get_argument("composer")
             dag_id = self.get_argument("dag_id")
             status = self.get_argument("status")
-            update_response = await client.update_job(composer, dag_id, status)
+            async with aiohttp.ClientSession() as client_session:
+                client = airflow.Client(
+                    await credentials.get_cached(), self.log, client_session
+                )
+                update_response = await client.update_job(composer, dag_id, status)
             if update_response == 0:
                 self.finish({"status": 0})
             else:
@@ -76,15 +86,18 @@ class DagRunController(APIHandler):
     @tornado.web.authenticated
     async def get(self):
         try:
-            client = airflow.Client(await credentials.get_cached(), self.log)
             composer_name = self.get_argument("composer")
             dag_id = self.get_argument("dag_id")
             start_date = self.get_argument("start_date")
             offset = self.get_argument("offset")
             end_date = self.get_argument("end_date")
-            dag_run_list = await client.list_dag_runs(
-                composer_name, dag_id, start_date, end_date, offset
-            )
+            async with aiohttp.ClientSession() as client_session:
+                client = airflow.Client(
+                    await credentials.get_cached(), self.log, client_session
+                )
+                dag_run_list = await client.list_dag_runs(
+                    composer_name, dag_id, start_date, end_date, offset
+                )
             self.finish(json.dumps(dag_run_list))
         except Exception as e:
             self.log.exception(f"Error fetching dag run list {str(e)}")
@@ -95,13 +108,16 @@ class DagRunTaskController(APIHandler):
     @tornado.web.authenticated
     async def get(self):
         try:
-            client = airflow.Client(await credentials.get_cached(), self.log)
             composer_name = self.get_argument("composer")
             dag_id = self.get_argument("dag_id")
             dag_run_id = self.get_argument("dag_run_id")
-            dag_run_list = await client.list_dag_run_task(
-                composer_name, dag_id, dag_run_id
-            )
+            async with aiohttp.ClientSession() as client_session:
+                client = airflow.Client(
+                    await credentials.get_cached(), self.log, client_session
+                )
+                dag_run_list = await client.list_dag_run_task(
+                    composer_name, dag_id, dag_run_id
+                )
             self.finish(json.dumps(dag_run_list))
         except Exception as e:
             self.log.exception(f"Error fetching dag run tasks: {str(e)}")
@@ -112,15 +128,18 @@ class DagRunTaskLogsController(APIHandler):
     @tornado.web.authenticated
     async def get(self):
         try:
-            client = airflow.Client(await credentials.get_cached(), self.log)
             composer_name = self.get_argument("composer")
             dag_id = self.get_argument("dag_id")
             dag_run_id = self.get_argument("dag_run_id")
             task_id = self.get_argument("task_id")
             task_try_number = self.get_argument("task_try_number")
-            dag_run_list = await client.list_dag_run_task_logs(
-                composer_name, dag_id, dag_run_id, task_id, task_try_number
-            )
+            async with aiohttp.ClientSession() as client_session:
+                client = airflow.Client(
+                    await credentials.get_cached(), self.log, client_session
+                )
+                dag_run_list = await client.list_dag_run_task_logs(
+                    composer_name, dag_id, dag_run_id, task_id, task_try_number
+                )
             self.finish(json.dumps(dag_run_list))
         except Exception as e:
             self.log.exception(f"Error fetching dag run task logs: {str(e)}")
@@ -131,10 +150,13 @@ class EditDagController(APIHandler):
     @tornado.web.authenticated
     async def get(self):
         try:
-            client = airflow.Client(await credentials.get_cached(), self.log)
             bucket_name = self.get_argument("bucket_name")
             dag_id = self.get_argument("dag_id")
-            dag_details = await client.edit_jobs(dag_id, bucket_name)
+            async with aiohttp.ClientSession() as client_session:
+                client = airflow.Client(
+                    await credentials.get_cached(), self.log, client_session
+                )
+                dag_details = await client.edit_jobs(dag_id, bucket_name)
             self.finish(json.dumps(dag_details))
         except Exception as e:
             self.log.exception("Error getting dag details")
@@ -145,9 +167,12 @@ class ImportErrorController(APIHandler):
     @tornado.web.authenticated
     async def get(self):
         try:
-            client = airflow.Client(await credentials.get_cached(), self.log)
             composer_name = self.get_argument("composer")
-            import_errors_list = await client.list_import_errors(composer_name)
+            async with aiohttp.ClientSession() as client_session:
+                client = airflow.Client(
+                    await credentials.get_cached(), self.log, client_session
+                )
+                import_errors_list = await client.list_import_errors(composer_name)
             self.finish(json.dumps(import_errors_list))
         except Exception as e:
             self.log.exception("Error fetching import error list")
@@ -158,10 +183,13 @@ class TriggerDagController(APIHandler):
     @tornado.web.authenticated
     async def get(self):
         try:
-            client = airflow.Client(await credentials.get_cached(), self.log)
             dag_id = self.get_argument("dag_id")
             composer = self.get_argument("composer")
-            trigger = await client.dag_trigger(dag_id, composer)
+            async with aiohttp.ClientSession() as client_session:
+                client = airflow.Client(
+                    await credentials.get_cached(), self.log, client_session
+                )
+                trigger = await client.dag_trigger(dag_id, composer)
             self.finish(json.dumps(trigger))
         except Exception as e:
             self.log.exception("Error triggering dag")

--- a/dataproc_jupyter_plugin/controllers/bigquery.py
+++ b/dataproc_jupyter_plugin/controllers/bigquery.py
@@ -33,7 +33,9 @@ class DatasetController(APIHandler):
             page_token = self.get_argument("pageToken")
             project_id = self.get_argument("project_id")
             async with aiohttp.ClientSession() as client_session:
-                client = bigquery.Client(await credentials.get_cached(), self.log, client_session)
+                client = bigquery.Client(
+                    await credentials.get_cached(), self.log, client_session
+                )
                 dataset_list = await client.list_datasets(page_token, project_id)
             self.finish(json.dumps(dataset_list))
         except Exception as e:
@@ -49,7 +51,9 @@ class TableController(APIHandler):
             dataset_id = self.get_argument("dataset_id")
             project_id = self.get_argument("project_id")
             async with aiohttp.ClientSession() as client_session:
-                client = bigquery.Client(await credentials.get_cached(), self.log, client_session)
+                client = bigquery.Client(
+                    await credentials.get_cached(), self.log, client_session
+                )
                 table_list = await client.list_table(dataset_id, page_token, project_id)
             self.finish(json.dumps(table_list))
         except Exception as e:
@@ -64,7 +68,9 @@ class DatasetInfoController(APIHandler):
             dataset_id = self.get_argument("dataset_id")
             project_id = self.get_argument("project_id")
             async with aiohttp.ClientSession() as client_session:
-                client = bigquery.Client(await credentials.get_cached(), self.log, client_session)
+                client = bigquery.Client(
+                    await credentials.get_cached(), self.log, client_session
+                )
                 dataset_info = await client.list_dataset_info(dataset_id, project_id)
             self.finish(json.dumps(dataset_info))
         except Exception as e:
@@ -80,8 +86,12 @@ class TableInfoController(APIHandler):
             table_id = self.get_argument("table_id")
             project_id = self.get_argument("project_id")
             async with aiohttp.ClientSession() as client_session:
-                client = bigquery.Client(await credentials.get_cached(), self.log, client_session)
-                table_info = await client.list_table_info(dataset_id, table_id, project_id)
+                client = bigquery.Client(
+                    await credentials.get_cached(), self.log, client_session
+                )
+                table_info = await client.list_table_info(
+                    dataset_id, table_id, project_id
+                )
             self.finish(json.dumps(table_info))
         except Exception as e:
             self.log.exception("Error fetching table information")
@@ -98,7 +108,9 @@ class PreviewController(APIHandler):
             start_index = self.get_argument("start_index")
             project_id = self.get_argument("project_id")
             async with aiohttp.ClientSession() as client_session:
-                client = bigquery.Client(await credentials.get_cached(), self.log, client_session)
+                client = bigquery.Client(
+                    await credentials.get_cached(), self.log, client_session
+                )
                 preview_data = await client.bigquery_preview_data(
                     dataset_id, table_id, max_results, start_index, project_id
                 )
@@ -136,7 +148,9 @@ class SearchController(APIHandler):
             system = self.get_argument("system")
             projects = await bq_projects_list()
             async with aiohttp.ClientSession() as client_session:
-                client = bigquery.Client(await credentials.get_cached(), self.log, client_session)
+                client = bigquery.Client(
+                    await credentials.get_cached(), self.log, client_session
+                )
                 search_data = await client.bigquery_search(
                     search_string, type, system, projects
                 )

--- a/dataproc_jupyter_plugin/controllers/bigquery.py
+++ b/dataproc_jupyter_plugin/controllers/bigquery.py
@@ -15,6 +15,7 @@
 
 import json
 
+import aiohttp
 import tornado
 from jupyter_server.base.handlers import APIHandler
 
@@ -31,8 +32,9 @@ class DatasetController(APIHandler):
         try:
             page_token = self.get_argument("pageToken")
             project_id = self.get_argument("project_id")
-            client = bigquery.Client(await credentials.get_cached(), self.log)
-            dataset_list = await client.list_datasets(page_token, project_id)
+            async with aiohttp.ClientSession() as client_session:
+                client = bigquery.Client(await credentials.get_cached(), self.log, client_session)
+                dataset_list = await client.list_datasets(page_token, project_id)
             self.finish(json.dumps(dataset_list))
         except Exception as e:
             self.log.exception("Error fetching datasets")
@@ -46,8 +48,9 @@ class TableController(APIHandler):
             page_token = self.get_argument("pageToken")
             dataset_id = self.get_argument("dataset_id")
             project_id = self.get_argument("project_id")
-            client = bigquery.Client(await credentials.get_cached(), self.log)
-            table_list = await client.list_table(dataset_id, page_token, project_id)
+            async with aiohttp.ClientSession() as client_session:
+                client = bigquery.Client(await credentials.get_cached(), self.log, client_session)
+                table_list = await client.list_table(dataset_id, page_token, project_id)
             self.finish(json.dumps(table_list))
         except Exception as e:
             self.log.exception("Error fetching datasets")
@@ -60,8 +63,9 @@ class DatasetInfoController(APIHandler):
         try:
             dataset_id = self.get_argument("dataset_id")
             project_id = self.get_argument("project_id")
-            client = bigquery.Client(await credentials.get_cached(), self.log)
-            dataset_info = await client.list_dataset_info(dataset_id, project_id)
+            async with aiohttp.ClientSession() as client_session:
+                client = bigquery.Client(await credentials.get_cached(), self.log, client_session)
+                dataset_info = await client.list_dataset_info(dataset_id, project_id)
             self.finish(json.dumps(dataset_info))
         except Exception as e:
             self.log.exception("Error fetching dataset information")
@@ -75,8 +79,9 @@ class TableInfoController(APIHandler):
             dataset_id = self.get_argument("dataset_id")
             table_id = self.get_argument("table_id")
             project_id = self.get_argument("project_id")
-            client = bigquery.Client(await credentials.get_cached(), self.log)
-            table_info = await client.list_table_info(dataset_id, table_id, project_id)
+            async with aiohttp.ClientSession() as client_session:
+                client = bigquery.Client(await credentials.get_cached(), self.log, client_session)
+                table_info = await client.list_table_info(dataset_id, table_id, project_id)
             self.finish(json.dumps(table_info))
         except Exception as e:
             self.log.exception("Error fetching table information")
@@ -92,10 +97,11 @@ class PreviewController(APIHandler):
             max_results = self.get_argument("max_results")
             start_index = self.get_argument("start_index")
             project_id = self.get_argument("project_id")
-            client = bigquery.Client(await credentials.get_cached(), self.log)
-            preview_data = await client.bigquery_preview_data(
-                dataset_id, table_id, max_results, start_index, project_id
-            )
+            async with aiohttp.ClientSession() as client_session:
+                client = bigquery.Client(await credentials.get_cached(), self.log, client_session)
+                preview_data = await client.bigquery_preview_data(
+                    dataset_id, table_id, max_results, start_index, project_id
+                )
             self.finish(json.dumps(preview_data))
         except Exception as e:
             self.log.exception("Error fetching preview data")
@@ -129,10 +135,11 @@ class SearchController(APIHandler):
             type = self.get_argument("type")
             system = self.get_argument("system")
             projects = await bq_projects_list()
-            client = bigquery.Client(await credentials.get_cached(), self.log)
-            search_data = await client.bigquery_search(
-                search_string, type, system, projects
-            )
+            async with aiohttp.ClientSession() as client_session:
+                client = bigquery.Client(await credentials.get_cached(), self.log, client_session)
+                search_data = await client.bigquery_search(
+                    search_string, type, system, projects
+                )
             self.finish(json.dumps(search_data))
         except Exception as e:
             self.log.exception("Error fetching search data")

--- a/dataproc_jupyter_plugin/controllers/dataproc.py
+++ b/dataproc_jupyter_plugin/controllers/dataproc.py
@@ -14,6 +14,7 @@
 
 import json
 
+import aiohttp
 import tornado
 from jupyter_server.base.handlers import APIHandler
 
@@ -27,8 +28,11 @@ class ClusterListController(APIHandler):
         try:
             page_token = self.get_argument("pageToken")
             page_size = self.get_argument("pageSize")
-            client = dataproc.Client(await credentials.get_cached(), self.log)
-            cluster_list = await client.list_clusters(page_size, page_token)
+            async with aiohttp.ClientSession() as client_session:
+                client = dataproc.Client(
+                    await credentials.get_cached(), self.log, client_session
+                )
+                cluster_list = await client.list_clusters(page_size, page_token)
             self.finish(json.dumps(cluster_list))
         except Exception as e:
             self.log.exception("Error fetching cluster list")
@@ -41,8 +45,11 @@ class RuntimeController(APIHandler):
         try:
             page_token = self.get_argument("pageToken")
             page_size = self.get_argument("pageSize")
-            client = dataproc.Client(await credentials.get_cached(), self.log)
-            runtime_list = await client.list_runtime(page_size, page_token)
+            async with aiohttp.ClientSession() as client_session:
+                client = dataproc.Client(
+                    await credentials.get_cached(), self.log, client_session
+                )
+                runtime_list = await client.list_runtime(page_size, page_token)
             self.finish(json.dumps(runtime_list))
         except Exception as e:
             self.log.exception(f"Error fetching runtime template list: {str(e)}")

--- a/dataproc_jupyter_plugin/services/airflow.py
+++ b/dataproc_jupyter_plugin/services/airflow.py
@@ -16,8 +16,6 @@ import re
 import subprocess
 import urllib
 
-import aiohttp
-
 from dataproc_jupyter_plugin import urls
 from dataproc_jupyter_plugin.commons.constants import (
     COMPOSER_SERVICE_NAME,
@@ -29,9 +27,7 @@ from dataproc_jupyter_plugin.commons.constants import (
 
 
 class Client:
-    client_session = aiohttp.ClientSession()
-
-    def __init__(self, credentials, log):
+    def __init__(self, credentials, log, client_session):
         self.log = log
         if not (
             ("access_token" in credentials)
@@ -43,6 +39,7 @@ class Client:
         self._access_token = credentials["access_token"]
         self.project_id = credentials["project_id"]
         self.region_id = credentials["region_id"]
+        self.client_session = client_session
 
     def create_headers(self):
         return {

--- a/dataproc_jupyter_plugin/services/bigquery.py
+++ b/dataproc_jupyter_plugin/services/bigquery.py
@@ -25,9 +25,7 @@ from dataproc_jupyter_plugin.commons.constants import (
 
 
 class Client:
-    client_session = aiohttp.ClientSession()
-
-    def __init__(self, credentials, log):
+    def __init__(self, credentials, log, client_session):
         self.log = log
         if not (
             ("access_token" in credentials)
@@ -39,6 +37,7 @@ class Client:
         self._access_token = credentials["access_token"]
         self.project_id = credentials["project_id"]
         self.region_id = credentials["region_id"]
+        self.client_session = client_session
 
     def create_headers(self):
         return {
@@ -52,7 +51,7 @@ class Client:
             api_endpoint = f"{bigquery_url}bigquery/v2/projects/{project_id}/datasets?pageToken={page_token}"
 
             async with self.client_session.get(
-                api_endpoint, headers=self.create_headers()
+                    api_endpoint, headers=self.create_headers()
             ) as response:
                 if response.status == 200:
                     resp = await response.json()

--- a/dataproc_jupyter_plugin/services/bigquery.py
+++ b/dataproc_jupyter_plugin/services/bigquery.py
@@ -51,7 +51,7 @@ class Client:
             api_endpoint = f"{bigquery_url}bigquery/v2/projects/{project_id}/datasets?pageToken={page_token}"
 
             async with self.client_session.get(
-                    api_endpoint, headers=self.create_headers()
+                api_endpoint, headers=self.create_headers()
             ) as response:
                 if response.status == 200:
                     resp = await response.json()

--- a/dataproc_jupyter_plugin/services/composer.py
+++ b/dataproc_jupyter_plugin/services/composer.py
@@ -15,8 +15,6 @@
 
 from typing import List
 
-import aiohttp
-
 from dataproc_jupyter_plugin import urls
 from dataproc_jupyter_plugin.commons.constants import (
     COMPOSER_SERVICE_NAME,
@@ -26,9 +24,7 @@ from dataproc_jupyter_plugin.models.models import ComposerEnvironment
 
 
 class Client:
-    client_session = aiohttp.ClientSession()
-
-    def __init__(self, credentials, log):
+    def __init__(self, credentials, log, client_session):
         self.log = log
         if not (
             ("access_token" in credentials)
@@ -40,6 +36,7 @@ class Client:
         self._access_token = credentials["access_token"]
         self.project_id = credentials["project_id"]
         self.region_id = credentials["region_id"]
+        self.client_session = client_session
 
     def create_headers(self):
         return {
@@ -86,4 +83,4 @@ class Client:
                     )
         except Exception as e:
             self.log.exception(f"Error fetching environments list: {str(e)}")
-            return f'{"Error fetching environments list": str(e)}'
+            return {"Error fetching environments list": str(e)}

--- a/dataproc_jupyter_plugin/services/dataproc.py
+++ b/dataproc_jupyter_plugin/services/dataproc.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import aiohttp
-
 from dataproc_jupyter_plugin import urls
 from dataproc_jupyter_plugin.commons.constants import (
     CONTENT_TYPE,
@@ -22,9 +20,7 @@ from dataproc_jupyter_plugin.commons.constants import (
 
 
 class Client:
-    client_session = aiohttp.ClientSession()
-
-    def __init__(self, credentials, log):
+    def __init__(self, credentials, log, client_session):
         self.log = log
         if not (
             ("access_token" in credentials)
@@ -36,6 +32,7 @@ class Client:
         self._access_token = credentials["access_token"]
         self.project_id = credentials["project_id"]
         self.region_id = credentials["region_id"]
+        self.client_session = client_session
 
     def create_headers(self):
         return {

--- a/dataproc_jupyter_plugin/tests/mocks.py
+++ b/dataproc_jupyter_plugin/tests/mocks.py
@@ -1,0 +1,83 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import aiohttp
+from google.cloud import jupyter_config
+
+from dataproc_jupyter_plugin import credentials
+
+
+async def mock_credentials():
+    return {
+        "project_id": "credentials-project",
+        "project_number": 12345,
+        "region_id": "mock-region",
+        "access_token": "mock-token",
+        "config_error": 0,
+        "login_error": 0,
+    }
+
+
+async def mock_config(field_name):
+    return None
+
+
+class _MockResponse:
+    def __init__(self, json):
+        self._json = json
+        self.status = 200
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args, **kwargs):
+        return
+
+    async def json(self):
+        return self._json
+
+
+class MockClientSession:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args, **kwargs):
+        return
+
+    def get(self, api_endpoint, headers=None):
+        return _MockResponse(
+            {
+                "api_endpoint": api_endpoint,
+                "headers": headers,
+            }
+        )
+
+    def post(self, api_endpoint, headers=None, json=None):
+        return _MockResponse(
+            {
+                "results": [
+                    {
+                        "api_endpoint": api_endpoint,
+                        "headers": headers,
+                        "json": json,
+                    }
+                ]
+            }
+        )
+
+
+def patch_mocks(monkeypatch):
+    monkeypatch.setattr(credentials, "get_cached", mock_credentials)
+    monkeypatch.setattr(jupyter_config, "async_get_gcloud_config", mock_config)
+    monkeypatch.setattr(aiohttp, "ClientSession", MockClientSession)

--- a/dataproc_jupyter_plugin/tests/mocks.py
+++ b/dataproc_jupyter_plugin/tests/mocks.py
@@ -33,7 +33,7 @@ async def mock_config(field_name):
     return None
 
 
-class _MockResponse:
+class MockResponse:
     def __init__(self, json):
         self._json = json
         self.status = 200
@@ -56,7 +56,7 @@ class MockClientSession:
         return
 
     def get(self, api_endpoint, headers=None):
-        return _MockResponse(
+        return MockResponse(
             {
                 "api_endpoint": api_endpoint,
                 "headers": headers,
@@ -64,7 +64,7 @@ class MockClientSession:
         )
 
     def post(self, api_endpoint, headers=None, json=None):
-        return _MockResponse(
+        return MockResponse(
             {
                 "results": [
                     {

--- a/dataproc_jupyter_plugin/tests/mocks.py
+++ b/dataproc_jupyter_plugin/tests/mocks.py
@@ -34,9 +34,10 @@ async def mock_config(field_name):
 
 
 class MockResponse:
-    def __init__(self, json):
+    def __init__(self, json, status=200, text=None):
         self._json = json
-        self.status = 200
+        self._text = text
+        self.status = status
 
     async def __aenter__(self):
         return self
@@ -46,6 +47,9 @@ class MockResponse:
 
     async def json(self):
         return self._json
+
+    async def text(self, encoding=None):
+        return self._text or json.dumps(self._json)
 
 
 class MockClientSession:

--- a/dataproc_jupyter_plugin/tests/test_bigquery.py
+++ b/dataproc_jupyter_plugin/tests/test_bigquery.py
@@ -13,73 +13,15 @@
 # limitations under the License.
 
 import json
-from unittest.mock import Mock
 
-import aiohttp
 from google.cloud import jupyter_config
 
 from dataproc_jupyter_plugin import credentials
-
-
-async def mock_credentials():
-    return {
-        "project_id": "credentials-project",
-        "project_number": 12345,
-        "region_id": "mock-region",
-        "access_token": "mock-token",
-        "config_error": 0,
-        "login_error": 0,
-    }
-
-
-class MockResponse():
-    def __init__(self, json):
-        self._json = json
-        self.status = 200
-    
-    async def __aenter__(self):
-        return self
-
-    async def __aexit__(self, *args, **kwargs):
-        return
-
-    async def json(self):
-        return self._json
-
-
-class MockClientSession():
-    async def __aenter__(self):
-        return self
-
-    async def __aexit__(self, *args, **kwargs):
-        return
-
-    def get(self, api_endpoint, headers=None):
-        return MockResponse({
-            "api_endpoint": api_endpoint,
-            "headers": headers,
-        })
-
-    def post(self, api_endpoint, headers=None, json=None):
-        return MockResponse({
-            "results": [
-                {
-                    "api_endpoint": api_endpoint,
-                    "headers": headers,
-                    "json": json,
-                }
-            ]
-        })
-
-
-async def mock_config(field_name):
-    return None
+from dataproc_jupyter_plugin.tests import mocks
 
 
 async def test_list_datasets(monkeypatch, jp_fetch):
-    monkeypatch.setattr(credentials, "get_cached", mock_credentials)
-    monkeypatch.setattr(jupyter_config, "async_get_gcloud_config", mock_config)
-    monkeypatch.setattr(aiohttp,  "ClientSession", MockClientSession)
+    mocks.patch_mocks(monkeypatch)
 
     mock_project_id = "mock-project-id"
     mock_page_token = "mock-page-token"
@@ -101,9 +43,8 @@ async def test_list_datasets_with_invalid_credentials(monkeypatch, jp_fetch):
     async def mock_credentials():
         return {}
 
+    mocks.patch_mocks(monkeypatch)
     monkeypatch.setattr(credentials, "get_cached", mock_credentials)
-    monkeypatch.setattr(jupyter_config, "async_get_gcloud_config", mock_config)
-    monkeypatch.setattr(aiohttp, "ClientSession", MockClientSession)
     response = await jp_fetch(
         "dataproc-plugin",
         "bigQueryDataset",
@@ -115,9 +56,7 @@ async def test_list_datasets_with_invalid_credentials(monkeypatch, jp_fetch):
 
 
 async def test_list_tables(monkeypatch, jp_fetch):
-    monkeypatch.setattr(credentials, "get_cached", mock_credentials)
-    monkeypatch.setattr(jupyter_config, "async_get_gcloud_config", mock_config)
-    monkeypatch.setattr(aiohttp, "ClientSession", MockClientSession)
+    mocks.patch_mocks(monkeypatch)
 
     mock_dataset_id = "mock-dataset-id"
     mock_project_id = "mock-project-id"
@@ -141,9 +80,7 @@ async def test_list_tables(monkeypatch, jp_fetch):
 
 
 async def test_dataset_info(monkeypatch, jp_fetch):
-    monkeypatch.setattr(credentials, "get_cached", mock_credentials)
-    monkeypatch.setattr(jupyter_config, "async_get_gcloud_config", mock_config)
-    monkeypatch.setattr(aiohttp, "ClientSession", MockClientSession)
+    mocks.patch_mocks(monkeypatch)
 
     mock_dataset_id = "mock-dataset-id"
     mock_project_id = "mock-project-id"
@@ -165,9 +102,7 @@ async def test_dataset_info(monkeypatch, jp_fetch):
 
 
 async def test_table_info(monkeypatch, jp_fetch):
-    monkeypatch.setattr(credentials, "get_cached", mock_credentials)
-    monkeypatch.setattr(jupyter_config, "async_get_gcloud_config", mock_config)
-    monkeypatch.setattr(aiohttp, "ClientSession", MockClientSession)
+    mocks.patch_mocks(monkeypatch)
 
     mock_dataset_id = "mock-dataset-id"
     mock_project_id = "mock-project-id"
@@ -191,9 +126,7 @@ async def test_table_info(monkeypatch, jp_fetch):
 
 
 async def test_preview(monkeypatch, jp_fetch):
-    monkeypatch.setattr(credentials, "get_cached", mock_credentials)
-    monkeypatch.setattr(jupyter_config, "async_get_gcloud_config", mock_config)
-    monkeypatch.setattr(aiohttp, "ClientSession", MockClientSession)
+    mocks.patch_mocks(monkeypatch)
 
     mock_dataset_id = "mock-dataset-id"
     mock_max_results = "mock-max-results"
@@ -221,8 +154,7 @@ async def test_preview(monkeypatch, jp_fetch):
 
 
 async def test_projects_list(monkeypatch, jp_fetch):
-    monkeypatch.setattr(credentials, "get_cached", mock_credentials)
-    monkeypatch.setattr(aiohttp, "ClientSession", MockClientSession)
+    mocks.patch_mocks(monkeypatch)
 
     response = await jp_fetch(
         "dataproc-plugin",
@@ -237,10 +169,8 @@ async def test_search(monkeypatch, jp_fetch):
     async def mock_config(config_field):
         return ""
 
+    mocks.patch_mocks(monkeypatch)
     monkeypatch.setattr(jupyter_config, "async_get_gcloud_config", mock_config)
-    monkeypatch.setattr(credentials, "get_cached", mock_credentials)
-    monkeypatch.setattr(jupyter_config, "async_get_gcloud_config", mock_config)
-    monkeypatch.setattr(aiohttp, "ClientSession", MockClientSession)
 
     mock_search_string = "mock-search-string"
     mock_system = "mock-system"

--- a/dataproc_jupyter_plugin/tests/test_dataproc.py
+++ b/dataproc_jupyter_plugin/tests/test_dataproc.py
@@ -13,43 +13,13 @@
 # limitations under the License.
 
 import json
-from unittest.mock import Mock
 
-import requests
-from google.cloud import jupyter_config
-
-from dataproc_jupyter_plugin import credentials
-
-
-async def mock_credentials():
-    return {
-        "project_id": "credentials-project",
-        "project_number": 12345,
-        "region_id": "mock-region",
-        "access_token": "mock-token",
-        "config_error": 0,
-        "login_error": 0,
-    }
-
-
-def mock_get(api_endpoint, headers=None):
-    response = Mock()
-    response.status_code = 200
-    response.json.return_value = {
-        "api_endpoint": api_endpoint,
-        "headers": headers,
-    }
-    return response
-
-
-async def mock_config(field_name):
-    return None
+from dataproc_jupyter_plugin.tests import mocks
 
 
 async def test_list_clusters(monkeypatch, jp_fetch):
-    monkeypatch.setattr(credentials, "get_cached", mock_credentials)
-    monkeypatch.setattr(jupyter_config, "async_get_gcloud_config", mock_config)
-    monkeypatch.setattr(requests, "get", mock_get)
+    mocks.patch_mocks(monkeypatch)
+
     mock_project_id = "credentials-project"
     mock_page_token = "mock-page-token"
     mock_region_id = "mock-region"
@@ -69,9 +39,8 @@ async def test_list_clusters(monkeypatch, jp_fetch):
 
 
 async def test_list_runtime(monkeypatch, jp_fetch):
-    monkeypatch.setattr(credentials, "get_cached", mock_credentials)
-    monkeypatch.setattr(requests, "get", mock_get)
-    monkeypatch.setattr(jupyter_config, "async_get_gcloud_config", mock_config)
+    mocks.patch_mocks(monkeypatch)
+
     mock_project_id = "credentials-project"
     mock_page_token = "mock-page-token"
     mock_region_id = "mock-region"


### PR DESCRIPTION
The pytest unit tests were all broken by https://github.com/GoogleCloudDataproc/dataproc-jupyter-plugin/pull/155 which modified the server-side code, but did not update the corresponding tests.

This PR fixes those tests.

However, the fixed tests revealed that the change in #155 was not correctly using the aiohttp library. This misusage did not actually cause functionality to break when running in a real Jupyter server, but it did break when running in the in-test version of the Jupyter server running in our tests.

Accordingly, this PR also fixes the usages of the aiohttp library to follow the documented pattern for calling into that library.