### PR TITLE
Edit dag notebook and Session Detail in notebook fixes

### DIFF
--- a/src/controls/NotebookButtonExtension.tsx
+++ b/src/controls/NotebookButtonExtension.tsx
@@ -58,6 +58,7 @@ class NotebookButtonExtensionPoint implements IDisposable {
   isDisposed: boolean;
   private readonly sparkLogsButton: ToolbarButton;
   private readonly sessionDetailsButton: ToolbarButton;
+  private readonly sessionDetailsButtonDisable: ToolbarButton;
   private readonly notebookSchedulerButton: ToolbarButton;
   private sessionId?: string;
 
@@ -97,6 +98,18 @@ class NotebookButtonExtensionPoint implements IDisposable {
       1000,
       'session-details',
       this.sessionDetailsButton
+    );
+    this.sessionDetailsButton.hide();
+
+    this.sessionDetailsButtonDisable = new ToolbarButton({
+      icon: iconSessionLogs,
+      tooltip: 'Please wait till session is ready',
+      className: 'dark-theme-logs-disable'
+    });
+    this.panel.toolbar.insertItem(
+      1000,
+      'session-details-disable',
+      this.sessionDetailsButtonDisable
     );
 
     this.notebookSchedulerButton = new ToolbarButton({
@@ -157,8 +170,8 @@ class NotebookButtonExtensionPoint implements IDisposable {
    *  3) Show or hide the log and session details buttons as necessary.
    */
   private onKernelChanged = async (session: ISessionContext) => {
-    this.sparkLogsButton.hide();
     this.sessionDetailsButton.hide();
+
     // Get the current kernel ID and look for the kernel in the kernel API.
     const currentId = session.session?.kernel?.id;
     const runningKernels = await KernelAPI.listRunning();
@@ -173,6 +186,7 @@ class NotebookButtonExtensionPoint implements IDisposable {
       // hide everything and abort.
       this.sparkLogsButton.hide();
       this.sessionDetailsButton.hide();
+      this.sessionDetailsButtonDisable.hide();
       this.sessionId = undefined;
       this.shsUri = undefined;
       return;
@@ -190,12 +204,14 @@ class NotebookButtonExtensionPoint implements IDisposable {
       // TODO: fix this for Cluster Notebooks.
       this.sparkLogsButton.hide();
       this.sessionDetailsButton.hide();
+      this.sessionDetailsButtonDisable.hide();
       this.sessionId = undefined;
       this.shsUri = undefined;
       return;
     }
 
     // If session ID is specified, show session detail button.
+    this.sessionDetailsButtonDisable.hide();
     this.sessionDetailsButton.show();
 
     // Fetch session details (we care about the SHS URL) from OnePlatform.

--- a/src/controls/NotebookButtonExtension.tsx
+++ b/src/controls/NotebookButtonExtension.tsx
@@ -31,6 +31,7 @@ import { SessionTemplate } from '../sessions/sessionTemplate';
 import serverlessIcon from '../../style/icons/serverless_icon.svg';
 import notebookSchedulerIcon from '../../style/icons/scheduler_calendar_month.svg';
 import { NotebookScheduler } from '../scheduler/notebookScheduler';
+import { ISettingRegistry } from '@jupyterlab/settingregistry';
 
 const iconLogs = new LabIcon({
   name: 'launcher:logs-icon',
@@ -69,6 +70,7 @@ class NotebookButtonExtensionPoint implements IDisposable {
     private readonly panel: NotebookPanel,
     private readonly context: DocumentRegistry.IContext<INotebookModel>,
     private readonly app: JupyterLab,
+    private readonly settingRegistry: ISettingRegistry,
     private readonly launcher: ILauncher,
     private readonly themeManager: IThemeManager
   ) {
@@ -96,6 +98,7 @@ class NotebookButtonExtensionPoint implements IDisposable {
       'session-details',
       this.sessionDetailsButton
     );
+
     this.notebookSchedulerButton = new ToolbarButton({
       icon: iconNotebookScheduler,
       onClick: () => this.onNotebookSchedulerClick(),
@@ -113,6 +116,7 @@ class NotebookButtonExtensionPoint implements IDisposable {
     const content = new NotebookScheduler(
       this.app as JupyterLab,
       this.themeManager,
+      this.settingRegistry as ISettingRegistry,
       this.context
     );
     const widget = new MainAreaWidget<NotebookScheduler>({ content });
@@ -228,6 +232,7 @@ export class NotebookButtonExtension
 {
   constructor(
     private app: JupyterLab,
+    private settingRegistry: ISettingRegistry,
     private launcher: ILauncher,
     private themeManager: IThemeManager
   ) {}
@@ -240,6 +245,7 @@ export class NotebookButtonExtension
       panel,
       context,
       this.app,
+      this.settingRegistry,
       this.launcher,
       this.themeManager
     );

--- a/src/controls/NotebookButtonExtension.tsx
+++ b/src/controls/NotebookButtonExtension.tsx
@@ -157,6 +157,8 @@ class NotebookButtonExtensionPoint implements IDisposable {
    *  3) Show or hide the log and session details buttons as necessary.
    */
   private onKernelChanged = async (session: ISessionContext) => {
+    this.sparkLogsButton.hide();
+    this.sessionDetailsButton.hide();
     // Get the current kernel ID and look for the kernel in the kernel API.
     const currentId = session.session?.kernel?.id;
     const runningKernels = await KernelAPI.listRunning();

--- a/src/index.ts
+++ b/src/index.ts
@@ -255,7 +255,12 @@ const extension: JupyterFrontEndPlugin<void> = {
 
     app.docRegistry.addWidgetExtension(
       'Notebook',
-      new NotebookButtonExtension(app as JupyterLab, launcher, themeManager)
+      new NotebookButtonExtension(
+        app as JupyterLab,
+        settingRegistry as ISettingRegistry,
+        launcher,
+        themeManager
+      )
     );
 
     const loadDpmsWidget = (value: string) => {
@@ -533,6 +538,7 @@ const extension: JupyterFrontEndPlugin<void> = {
         const content = new NotebookScheduler(
           app as JupyterLab,
           themeManager,
+          settingRegistry as ISettingRegistry,
           ''
         );
         const widget = new MainAreaWidget<NotebookScheduler>({ content });

--- a/src/scheduler/createNotebookScheduler.tsx
+++ b/src/scheduler/createNotebookScheduler.tsx
@@ -45,6 +45,7 @@ import errorIcon from '../../style/icons/error_icon.svg';
 import { Button } from '@mui/material';
 import { scheduleMode } from '../utils/const';
 import { scheduleValueExpression } from '../utils/const';
+import { ISettingRegistry } from '@jupyterlab/settingregistry';
 
 interface IDagList {
   jobid: string;
@@ -66,11 +67,13 @@ const iconError = new LabIcon({
 const CreateNotebookScheduler = ({
   themeManager,
   app,
-  context
+  context,
+  settingRegistry
 }: {
   themeManager: IThemeManager;
   app: JupyterLab;
   context: any;
+  settingRegistry: ISettingRegistry;
 }): JSX.Element => {
   const [jobNameSelected, setJobNameSelected] = useState('');
   const [inputFileSelected, setInputFileSelected] = useState('');
@@ -407,6 +410,7 @@ const CreateNotebookScheduler = ({
         <NotebookJobComponent
           app={app}
           themeManager={themeManager}
+          settingRegistry={settingRegistry}
           composerSelectedFromCreate={composerSelected}
           setCreateCompleted={setCreateCompleted}
           setJobNameSelected={setJobNameSelected}

--- a/src/scheduler/listNotebookScheduler.tsx
+++ b/src/scheduler/listNotebookScheduler.tsx
@@ -491,13 +491,20 @@ function listNotebookScheduler({
     setIsPreviewEnabled(previewEnabled);
   };
 
+  const openEditDagNotebookFile = async () => {
+    let filePath = inputNotebookFilePath.replace('gs://', 'gs:');
+    const result: any = await app.commands.execute('docmanager:open', {
+      path: filePath
+    });
+    setInputNotebookFilePath('');
+    if (result) {
+      setEditNotebookLoading('');
+    }
+  };
+
   useEffect(() => {
     if (inputNotebookFilePath !== '') {
-      let filePath = inputNotebookFilePath.replace('gs://', 'gs:');
-      app.commands.execute('docmanager:open', {
-        path: filePath
-      });
-      setInputNotebookFilePath('');
+      openEditDagNotebookFile();
     }
   }, [inputNotebookFilePath]);
 

--- a/src/scheduler/listNotebookScheduler.tsx
+++ b/src/scheduler/listNotebookScheduler.tsx
@@ -228,7 +228,6 @@ function listNotebookScheduler({
       await SchedulerService.editNotebookSchedulerService(
         bucketName,
         jobid,
-        isPreviewEnabled,
         setInputNotebookFilePath,
         setEditNotebookLoading
       );
@@ -420,28 +419,29 @@ function listNotebookScheduler({
             />
           </div>
         )}
-        {data.jobid === editNotebookLoading ? (
-          <div className="icon-buttons-style">
-            <CircularProgress
-              size={18}
-              aria-label="Loading Spinner"
-              data-testid="loader"
-            />
-          </div>
-        ) : (
-          <div
-            role="button"
-            className="icon-buttons-style"
-            title="Edit Notebook"
-            data-jobid={data.jobid}
-            onClick={e => handleEditNotebook(e)}
-          >
-            <iconEditDag.react
-              tag="div"
-              className="icon-white logo-alignment-style"
-            />
-          </div>
-        )}
+        {isPreviewEnabled &&
+          (data.jobid === editNotebookLoading ? (
+            <div className="icon-buttons-style">
+              <CircularProgress
+                size={18}
+                aria-label="Loading Spinner"
+                data-testid="loader"
+              />
+            </div>
+          ) : (
+            <div
+              role="button"
+              className="icon-buttons-style"
+              title="Edit Notebook"
+              data-jobid={data.jobid}
+              onClick={e => handleEditNotebook(e)}
+            >
+              <iconEditDag.react
+                tag="div"
+                className="icon-white logo-alignment-style"
+              />
+            </div>
+          ))}
         <div
           role="button"
           className="icon-buttons-style"

--- a/src/scheduler/listNotebookScheduler.tsx
+++ b/src/scheduler/listNotebookScheduler.tsx
@@ -493,11 +493,11 @@ function listNotebookScheduler({
 
   const openEditDagNotebookFile = async () => {
     let filePath = inputNotebookFilePath.replace('gs://', 'gs:');
-    const result: any = await app.commands.execute('docmanager:open', {
+    const openNotebookFile: any = await app.commands.execute('docmanager:open', {
       path: filePath
     });
     setInputNotebookFilePath('');
-    if (result) {
+    if (openNotebookFile) {
       setEditNotebookLoading('');
     }
   };

--- a/src/scheduler/notebookJobs.tsx
+++ b/src/scheduler/notebookJobs.tsx
@@ -22,9 +22,11 @@ import { IThemeManager } from '@jupyterlab/apputils';
 import ListNotebookScheduler from './listNotebookScheduler';
 import ExecutionHistory from './executionHistory';
 import { scheduleMode } from '../utils/const';
+import { ISettingRegistry } from '@jupyterlab/settingregistry';
 
 const NotebookJobComponent = ({
   app,
+  settingRegistry,
   composerSelectedFromCreate,
   setCreateCompleted,
   setJobNameSelected,
@@ -55,6 +57,7 @@ const NotebookJobComponent = ({
 }: {
   app: JupyterLab;
   themeManager: IThemeManager;
+  settingRegistry: ISettingRegistry;
   composerSelectedFromCreate: string;
   setCreateCompleted?: (value: boolean) => void;
   setJobNameSelected?: (value: string) => void;
@@ -116,6 +119,7 @@ const NotebookJobComponent = ({
           <div>
             <ListNotebookScheduler
               app={app}
+              settingRegistry={settingRegistry}
               handleDagIdSelection={handleDagIdSelection}
               backButtonComposerName={backComposerName}
               composerSelectedFromCreate={composerSelectedFromCreate}
@@ -156,21 +160,25 @@ const NotebookJobComponent = ({
 
 export class NotebookJobs extends DataprocWidget {
   app: JupyterLab;
+  settingRegistry: ISettingRegistry;
   composerSelectedFromCreate: string;
 
   constructor(
     app: JupyterLab,
+    settingRegistry: ISettingRegistry,
     themeManager: IThemeManager,
     composerSelectedFromCreate: string
   ) {
     super(themeManager);
     this.app = app;
+    this.settingRegistry = settingRegistry;
     this.composerSelectedFromCreate = composerSelectedFromCreate;
   }
   renderInternal(): React.JSX.Element {
     return (
       <NotebookJobComponent
         app={this.app}
+        settingRegistry={this.settingRegistry}
         themeManager={this.themeManager}
         composerSelectedFromCreate={this.composerSelectedFromCreate}
       />

--- a/src/scheduler/notebookScheduler.tsx
+++ b/src/scheduler/notebookScheduler.tsx
@@ -24,15 +24,18 @@ import CreateNotebookScheduler from './createNotebookScheduler';
 
 import { DocumentRegistry } from '@jupyterlab/docregistry';
 import { INotebookModel } from '@jupyterlab/notebook';
+import { ISettingRegistry } from '@jupyterlab/settingregistry';
 
 const NotebookSchedulerComponent = ({
   themeManager,
   app,
-  context
+  context,
+  settingRegistry
 }: {
   themeManager: IThemeManager;
   app: JupyterLab;
   context: DocumentRegistry.IContext<INotebookModel> | string;
+  settingRegistry: ISettingRegistry;
 }): JSX.Element => {
   return (
     <div className="component-level">
@@ -40,6 +43,7 @@ const NotebookSchedulerComponent = ({
         themeManager={themeManager}
         app={app}
         context={context}
+        settingRegistry={settingRegistry}
       />
     </div>
   );
@@ -48,15 +52,18 @@ const NotebookSchedulerComponent = ({
 export class NotebookScheduler extends DataprocWidget {
   app: JupyterLab;
   context: DocumentRegistry.IContext<INotebookModel> | string;
+  settingRegistry: ISettingRegistry;
 
   constructor(
     app: JupyterLab,
     themeManager: IThemeManager,
+    settingRegistry: ISettingRegistry,
     context: DocumentRegistry.IContext<INotebookModel> | string
   ) {
     super(themeManager);
     this.app = app;
     this.context = context;
+    this.settingRegistry = settingRegistry;
   }
 
   renderInternal(): React.JSX.Element {
@@ -65,6 +72,7 @@ export class NotebookScheduler extends DataprocWidget {
         themeManager={this.themeManager}
         app={this.app}
         context={this.context}
+        settingRegistry={this.settingRegistry}
       />
     );
   }

--- a/src/scheduler/schedulerServices.tsx
+++ b/src/scheduler/schedulerServices.tsx
@@ -312,7 +312,6 @@ export class SchedulerService {
         method: 'POST'
       });
       setInputNotebookFilePath(formattedResponse.input_filename);
-      setEditNotebookLoading('');
     } catch (reason) {
       setEditNotebookLoading('');
       toast.error(

--- a/src/scheduler/schedulerServices.tsx
+++ b/src/scheduler/schedulerServices.tsx
@@ -302,21 +302,28 @@ export class SchedulerService {
   static editNotebookSchedulerService = async (
     bucketName: string,
     dagId: string,
+    isPreviewEnabled: boolean,
     setInputNotebookFilePath: (value: string) => void,
     setEditNotebookLoading: (value: string) => void
   ) => {
-    setEditNotebookLoading(dagId);
-    try {
-      const serviceURL = `editJobScheduler?&dag_id=${dagId}&bucket_name=${bucketName}`;
-      const formattedResponse: any = await requestAPI(serviceURL, {method: 'POST'});
-      setInputNotebookFilePath(formattedResponse.input_filename);
-      setEditNotebookLoading('');
-    } catch (reason) {
-      setEditNotebookLoading('');
-      toast.error(
-        `Error on POST {dataToSend}.\n${reason}`,
-        toastifyCustomStyle
-      );
+    if (!isPreviewEnabled) {
+      toast.error(`GCS is not enabled to open notebook`, toastifyCustomStyle);
+    } else {
+      setEditNotebookLoading(dagId);
+      try {
+        const serviceURL = `editJobScheduler?&dag_id=${dagId}&bucket_name=${bucketName}`;
+        const formattedResponse: any = await requestAPI(serviceURL, {
+          method: 'POST'
+        });
+        setInputNotebookFilePath(formattedResponse.input_filename);
+        setEditNotebookLoading('');
+      } catch (reason) {
+        setEditNotebookLoading('');
+        toast.error(
+          `Error on POST {dataToSend}.\n${reason}`,
+          toastifyCustomStyle
+        );
+      }
     }
   };
 
@@ -355,7 +362,9 @@ export class SchedulerService {
     setEditDagLoading(dagId);
     try {
       const serviceURL = `editJobScheduler?&dag_id=${dagId}&bucket_name=${bucketName}`;
-      const formattedResponse: any = await requestAPI(serviceURL, {method: 'POST'});
+      const formattedResponse: any = await requestAPI(serviceURL, {
+        method: 'POST'
+      });
       if (
         setCreateCompleted &&
         setJobNameSelected &&
@@ -731,7 +740,7 @@ export class SchedulerService {
       const serviceURL = `dagDelete?composer=${composerSelected}&dag_id=${dag_id}&from_page=${fromPage}`;
       const deleteResponse: IUpdateSchedulerAPIResponse = await requestAPI(
         serviceURL,
-	{method: 'DELETE'}
+        { method: 'DELETE' }
       );
       if (deleteResponse.status === 0) {
         await SchedulerService.listDagInfoAPIService(
@@ -767,7 +776,7 @@ export class SchedulerService {
       const serviceURL = `dagUpdate?composer=${composerSelected}&dag_id=${dag_id}&status=${is_status_paused}`;
       const formattedResponse: IUpdateSchedulerAPIResponse = await requestAPI(
         serviceURL,
-	{method: 'POST'}
+        { method: 'POST' }
       );
       if (formattedResponse && formattedResponse.status === 0) {
         toast.success(
@@ -882,7 +891,7 @@ export class SchedulerService {
     try {
       const data: any = await requestAPI(
         `triggerDag?dag_id=${dagId}&composer=${composerSelectedList}`,
-	{method: 'POST'}
+        { method: 'POST' }
       );
       if (data) {
         toast.success(`${dagId} triggered successfully `, toastifyCustomStyle);

--- a/src/scheduler/schedulerServices.tsx
+++ b/src/scheduler/schedulerServices.tsx
@@ -302,28 +302,23 @@ export class SchedulerService {
   static editNotebookSchedulerService = async (
     bucketName: string,
     dagId: string,
-    isPreviewEnabled: boolean,
     setInputNotebookFilePath: (value: string) => void,
     setEditNotebookLoading: (value: string) => void
   ) => {
-    if (!isPreviewEnabled) {
-      toast.error(`GCS is not enabled to open notebook`, toastifyCustomStyle);
-    } else {
-      setEditNotebookLoading(dagId);
-      try {
-        const serviceURL = `editJobScheduler?&dag_id=${dagId}&bucket_name=${bucketName}`;
-        const formattedResponse: any = await requestAPI(serviceURL, {
-          method: 'POST'
-        });
-        setInputNotebookFilePath(formattedResponse.input_filename);
-        setEditNotebookLoading('');
-      } catch (reason) {
-        setEditNotebookLoading('');
-        toast.error(
-          `Error on POST {dataToSend}.\n${reason}`,
-          toastifyCustomStyle
-        );
-      }
+    setEditNotebookLoading(dagId);
+    try {
+      const serviceURL = `editJobScheduler?&dag_id=${dagId}&bucket_name=${bucketName}`;
+      const formattedResponse: any = await requestAPI(serviceURL, {
+        method: 'POST'
+      });
+      setInputNotebookFilePath(formattedResponse.input_filename);
+      setEditNotebookLoading('');
+    } catch (reason) {
+      setEditNotebookLoading('');
+      toast.error(
+        `Error on POST {dataToSend}.\n${reason}`,
+        toastifyCustomStyle
+      );
     }
   };
 

--- a/style/base.css
+++ b/style/base.css
@@ -116,6 +116,10 @@
 .logs-button {
   cursor: context-menu !important;
 }
+.dark-theme-logs-disable {
+  opacity: 0.5;
+  cursor: default !important;
+}
 body[data-jp-theme-name='JupyterLab Light'] .filter-search-gcs {
   padding: 0px 5px;
   background-color: var(--jp-layout-color0);
@@ -130,6 +134,12 @@ body[data-jp-theme-light='true'].scroll-fix-header {
 }
 body[data-jp-theme-name='JupyterLab Dark'] .dark-theme-logs path {
   fill: var(--jp-ui-font-color1);
+}
+
+body[data-jp-theme-name='JupyterLab Dark'] .dark-theme-logs-disable path {
+  fill: var(--jp-ui-font-color1);
+  opacity: 0.5;
+  cursor: default !important;
 }
 
 body[data-jp-theme-name='JupyterLab Dark'] .icon-white path {


### PR DESCRIPTION
1. Edit scheduled notebook doesn't work: Modified the code to show 'Edit scheduled notebook' button only if GCS feature is enabled in the plugin
2. Session Details icon doesn't work: Modified the code enable the Session details icon only once the session ID is available.