### PR TITLE
Not allow GET requests for URL handlers that change state on the server side

### DIFF
--- a/dataproc_jupyter_plugin/controllers/bigquery.py
+++ b/dataproc_jupyter_plugin/controllers/bigquery.py
@@ -141,7 +141,7 @@ class ProjectsController(APIHandler):
 
 class SearchController(APIHandler):
     @tornado.web.authenticated
-    async def get(self):
+    async def post(self):
         try:
             search_string = self.get_argument("search_string")
             type = self.get_argument("type")

--- a/dataproc_jupyter_plugin/controllers/executor.py
+++ b/dataproc_jupyter_plugin/controllers/executor.py
@@ -51,7 +51,7 @@ class ExecutorController(APIHandler):
 
 class DownloadOutputController(APIHandler):
     @tornado.web.authenticated
-    async def get(self):
+    async def post(self):
         try:
             composer_name = self.get_argument("composer")
             bucket_name = self.get_argument("bucket_name")

--- a/dataproc_jupyter_plugin/tests/test_bigquery.py
+++ b/dataproc_jupyter_plugin/tests/test_bigquery.py
@@ -183,6 +183,7 @@ async def test_search(monkeypatch, jp_fetch):
             "system": mock_system,
             "type": mock_type,
         },
+        method="POST",
     )
     assert response.code == 200
     payload = json.loads(response.body)["results"][0]

--- a/dataproc_jupyter_plugin/tests/test_bigquery.py
+++ b/dataproc_jupyter_plugin/tests/test_bigquery.py
@@ -184,6 +184,7 @@ async def test_search(monkeypatch, jp_fetch):
             "type": mock_type,
         },
         method="POST",
+        allow_nonstandard_methods=True,
     )
     assert response.code == 200
     payload = json.loads(response.body)["results"][0]

--- a/dataproc_jupyter_plugin/tests/test_executor.py
+++ b/dataproc_jupyter_plugin/tests/test_executor.py
@@ -129,6 +129,7 @@ async def test_download_dag_output(monkeypatch, returncode, expected_result, jp_
             "dag_id": mock_dag_id,
             "dag_run_id": mock_dag_run_id,
         },
+        method="POST",
     )
     assert response.code == 200
     payload = json.loads(response.body)
@@ -149,6 +150,7 @@ async def test_invalid_composer_name(monkeypatch, jp_fetch):
             "dag_id": mock_dag_id,
             "dag_run_id": mock_dag_run_id,
         },
+        method="POST",
     )
     assert response.code == 200
     payload = json.loads(response.body)
@@ -171,6 +173,7 @@ async def test_invalid_bucket_name(monkeypatch, jp_fetch):
             "dag_id": mock_dag_id,
             "dag_run_id": mock_dag_run_id,
         },
+        method="POST",
     )
     assert response.code == 200
     payload = json.loads(response.body)
@@ -193,6 +196,7 @@ async def test_invalid_dag_id(monkeypatch, jp_fetch):
             "dag_id": mock_dag_id,
             "dag_run_id": mock_dag_run_id,
         },
+        method="POST",
     )
     assert response.code == 200
     payload = json.loads(response.body)
@@ -215,6 +219,7 @@ async def test_invalid_dag_run_id(monkeypatch, jp_fetch):
             "dag_id": mock_dag_id,
             "dag_run_id": mock_dag_run_id,
         },
+        method="POST",
     )
     assert response.code == 200
     payload = json.loads(response.body)

--- a/dataproc_jupyter_plugin/tests/test_executor.py
+++ b/dataproc_jupyter_plugin/tests/test_executor.py
@@ -130,6 +130,7 @@ async def test_download_dag_output(monkeypatch, returncode, expected_result, jp_
             "dag_run_id": mock_dag_run_id,
         },
         method="POST",
+        allow_nonstandard_methods=True,
     )
     assert response.code == 200
     payload = json.loads(response.body)
@@ -151,6 +152,7 @@ async def test_invalid_composer_name(monkeypatch, jp_fetch):
             "dag_run_id": mock_dag_run_id,
         },
         method="POST",
+        allow_nonstandard_methods=True,
     )
     assert response.code == 200
     payload = json.loads(response.body)
@@ -174,6 +176,7 @@ async def test_invalid_bucket_name(monkeypatch, jp_fetch):
             "dag_run_id": mock_dag_run_id,
         },
         method="POST",
+        allow_nonstandard_methods=True,
     )
     assert response.code == 200
     payload = json.loads(response.body)
@@ -197,6 +200,7 @@ async def test_invalid_dag_id(monkeypatch, jp_fetch):
             "dag_run_id": mock_dag_run_id,
         },
         method="POST",
+        allow_nonstandard_methods=True,
     )
     assert response.code == 200
     payload = json.loads(response.body)
@@ -220,6 +224,7 @@ async def test_invalid_dag_run_id(monkeypatch, jp_fetch):
             "dag_run_id": mock_dag_run_id,
         },
         method="POST",
+        allow_nonstandard_methods=True,
     )
     assert response.code == 200
     payload = json.loads(response.body)

--- a/src/bigQuery/bigQueryService.tsx
+++ b/src/bigQuery/bigQueryService.tsx
@@ -407,7 +407,10 @@ export class BigQueryService {
     setSearchLoading(true);
     try {
       const data: any = await requestAPI(
-        `bigQuerySearch?search_string=${searchTerm}&type=(table|dataset)&system=bigquery`
+        `bigQuerySearch?search_string=${searchTerm}&type=(table|dataset)&system=bigquery`,
+        {
+          method: 'POST'
+        }
       );
       setSearchResponse(data);
     } catch (reason) {

--- a/src/scheduler/schedulerServices.tsx
+++ b/src/scheduler/schedulerServices.tsx
@@ -702,7 +702,9 @@ export class SchedulerService {
     try {
       dagRunId = encodeURIComponent(dagRunId);
       const serviceURL = `downloadOutput?composer=${composerName}&bucket_name=${bucketName}&dag_id=${dagId}&dag_run_id=${dagRunId}`;
-      const formattedResponse: any = await requestAPI(serviceURL);
+      const formattedResponse: any = await requestAPI(serviceURL, {
+        method: 'POST'
+      });
       dagRunId = decodeURIComponent(dagRunId);
       if (formattedResponse.status === 0) {
         toast.success(


### PR DESCRIPTION
bigQuerySearch handler and downloadOutput handler changed from GET to POST