### PR TITLE
Fix the Kokoro integration tests

### DIFF
--- a/ui-tests/playwright.config.js
+++ b/ui-tests/playwright.config.js
@@ -22,6 +22,7 @@ const baseConfig = require('@jupyterlab/galata/lib/playwright-config');
 
 module.exports = {
   ...baseConfig,
+  timeout: 120000,
   webServer: {
     command: 'jlpm start --allow-root',
     url: 'http://localhost:8888/lab',

--- a/ui-tests/tests/bigquery_dataset_explorer.spec.ts
+++ b/ui-tests/tests/bigquery_dataset_explorer.spec.ts
@@ -35,13 +35,19 @@ test('bigquery-dataset-explorer', async ({ page, request }) => {
       .getByRole('tab', { name: 'Dataset Explorer - BigQuery' })
       .click();
 
+    // Wait for the Dataset projects to populate.
     await page.waitForSelector('div[role="treeitem"].caret-icon.down');
 
-    await page.locator('div[role="treeitem"].caret-icon.down').nth(1).click();
-    await page.locator('div[role="treeitem"][aria-level="1"]').first().click();
-    await page.locator('div[role="treeitem"].caret-icon.down').nth(1).click();
+    // Expand the first dataset project. This should always be the `bigquery-public-data` one.
+    await page.locator('div[role="treeitem"].caret-icon.down').nth(0).click();
 
-    await page.locator('div[role="treeitem"][aria-level="2"]').first().click();
+    // Wait for the first dataset to be displayed, and then expand it.
+    await page.waitForSelector('div[role="treeitem"][aria-level="2"]');
+    await page.waitForSelector('div[role="treeitem"].caret-icon.down');
+    await page.locator('div[role="treeitem"].caret-icon.down').nth(0).click();
+
+    // Click on the first table displayed.
+    await page.locator('div[role="treeitem"][aria-level="3"]').first().click();
     await page.getByText('Schema', { exact: true }).click();
     await page.getByText('Preview', { exact: true }).click();
   } else {

--- a/ui-tests/tests/bigquery_dataset_explorer.spec.ts
+++ b/ui-tests/tests/bigquery_dataset_explorer.spec.ts
@@ -36,6 +36,7 @@ test('bigquery-dataset-explorer', async ({ page, request }) => {
       .click();
 
     // Wait for the Dataset projects to populate.
+    await page.waitForSelector('div[role="treeitem"][aria-level="1"]');
     await page.waitForSelector('div[role="treeitem"].caret-icon.down');
 
     // Expand the first dataset project. This should always be the `bigquery-public-data` one.


### PR DESCRIPTION
Our Kokoro intergration tests have recently started failing consistently with timeout errors.

This change tries to resolve that by doubling the test timeout from the default 60 seconds to 120 seconds.