### PR TITLE
version and default label fix - Do not Merge 

### DIFF
--- a/src/utils/const.ts
+++ b/src/utils/const.ts
@@ -16,7 +16,8 @@
  */
 
 import { requestAPI } from '../handler/handler';
-export const VERSION_DETAIL = '0.1.78';
+const { version } = require('../../package.json');
+export const VERSION_DETAIL = version;
 export const CREATE_CLUSTER_URL =
   'https://console.cloud.google.com/dataproc/clusters';
 export const CREATE_BATCH_URL =
@@ -170,7 +171,7 @@ export const DCU_HOURS = 3600000;
 export const GB_MONTHS = 2592000;
 export const TITLE_LAUNCHER_CATEGORY = 'Google Cloud Resources';
 export const SPARK_HISTORY_SERVER = 'Spark History Server';
-export const DEFAULT_LABEL_DETAIL = 'client:dataproc-jupyter-plugin';
+export const DEFAULT_LABEL_DETAIL = 'client:bigquery-jupyter-plugin';
 export const JOB_FIELDS_EXCLUDED = ['queryList', 'properties', 'args'];
 export const BATCH_FIELDS_EXCLUDED = ['queryList', 'properties'];
 export const KEY_MESSAGE =


### PR DESCRIPTION
1. version change- getting the current version from package.json
2. default label is changed from 'client:dataproc-jupyter-plugin' to  'client:bigquery-jupyter-plugin'