### PR TITLE
Notebook Templates - update reference to new repo url

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -461,7 +461,7 @@ const extension: JupyterFrontEndPlugin<void> = {
 
     const openBigQueryNotebook = async () => {
       const template = {
-        url: 'https://raw.githubusercontent.com/GoogleCloudPlatform/dataproc-ml-quickstart-notebooks/main/public_datasets/bigframes/bigframes_quickstart.ipynb'
+        url: 'https://raw.githubusercontent.com/GoogleCloudPlatform/ai-ml-recipes/main/public_datasets/bigframes/bigframes_quickstart.ipynb'
       };
       await NotebookTemplateService.handleClickService(
         template,

--- a/src/utils/const.ts
+++ b/src/utils/const.ts
@@ -184,7 +184,7 @@ export const NETWORK_TAG_MESSAGE =
 export const LOGIN_ERROR_MESSAGE =
   'Please navigate to Settings -> Google BigQuery Settings to login and continue';
 export const NOTEBOOK_TEMPLATES_LIST_URL =
-  'https://api.github.com/repos/GoogleCloudPlatform/dataproc-ml-quickstart-notebooks/contents/.ci/index.json';
+  'https://api.github.com/repos/GoogleCloudPlatform/ai-ml-recipes/contents/.ci/index.json';
 export type scheduleMode = 'runNow' | 'runSchedule';
 export const scheduleValueExpression = '30 17 * * 1-5'; //Expression for schedule Value in Scheduler Jobs
 export const PLUGIN_ID = 'dataproc_jupyter_plugin:plugin';


### PR DESCRIPTION
The repo https://github.com/GoogleCloudPlatform/dataproc-ml-quickstart-notebooks  
was renamed to https://github.com/GoogleCloudPlatform/ai-ml-recipes  
Github maintains both repo URLs valid after renaming a repo name, until a new repo is created using the old name.   
This PR updates the references to the repo to the new one.  