### PR TITLE
Bugfix: Included network name in the toast when subnets are not available

### DIFF
--- a/src/runtime/runtimeService.tsx
+++ b/src/runtime/runtimeService.tsx
@@ -613,7 +613,7 @@ export class RunTimeSerive {
                   message: string;
                 };
               }) => {
-                let transformedRegionList = responseResult?.items?.map(
+                let transformedRegionList = responseResult.items?.map(
                   (data: Region) => {
                     return data.name;
                   }
@@ -669,7 +669,6 @@ export class RunTimeSerive {
     setIsloadingNetwork: (value: boolean) => void
   ) => {
     setIsloadingNetwork(true);
- 
     const credentials = await authApi();
     const { COMPUTE } = await gcpServiceUrls;
     if (credentials) {

--- a/src/runtime/runtimeService.tsx
+++ b/src/runtime/runtimeService.tsx
@@ -285,7 +285,7 @@ export class RunTimeSerive {
             */
 
       const transformedSharedvpcSubNetworkList: string[] = responseResult.items
-        .map((data: { subnetwork: string }) => {
+        ?.map((data: { subnetwork: string }) => {
           // Extract region and subnet from the subnet URI.
           const matches =
             /\/compute\/v1\/projects\/(?<project>[\w\-]+)\/regions\/(?<region>[\w\-]+)\/subnetworks\/(?<subnetwork>[\w\-]+)/.exec(
@@ -711,22 +711,22 @@ export class RunTimeSerive {
                       setSubNetworkSelected(transformedServiceList[0]);
                     } else {
                       DataprocLoggingService.log(
-                        'There are no subnetworks with google private access enabled',
+                        `There are no subnetworks with google private access enabled for network ${subnetwork}`,
                         LOG_LEVEL.ERROR
                       );
                       toast.error(
-                        `There are no subnetworks with google private access enabled`,
+                        `There are no subnetworks with google private access enabled for network ${subnetwork}`,
                         toastifyCustomStyle
                       );
                     }
                   }
                 } else {
                   DataprocLoggingService.log(
-                    'No subNetworks found',
+                    `No subNetworks found for network ${subnetwork}`,
                     LOG_LEVEL.ERROR
                   );
                   toast.error(
-                    `No subNetworks found`,
+                    `No subNetworks found  for network ${subnetwork}`,
                     toastifyCustomStyle
                   );
                 }

--- a/src/runtime/runtimeService.tsx
+++ b/src/runtime/runtimeService.tsx
@@ -691,7 +691,7 @@ export class RunTimeSerive {
                   network: string;
                   privateIpGoogleAccess: boolean;
                 }[];
-                error: {
+                error?: {
                   message: string;
                   code: number;
                 };
@@ -701,7 +701,7 @@ export class RunTimeSerive {
                     item.network.split('/')[9] === subnetwork &&
                     item.privateIpGoogleAccess === true
                 );
-                if (filteredServices) {
+                if (filteredServices && filteredServices.length > 0) {
                   const transformedServiceList = filteredServices.map(
                     (data: { name: string }) => data.name
                   );
@@ -709,33 +709,29 @@ export class RunTimeSerive {
                   if (selectedRuntimeClone === undefined) {
                     if (transformedServiceList.length > 0) {
                       setSubNetworkSelected(transformedServiceList[0]);
-                    } else {
-                      DataprocLoggingService.log(
-                        `There are no subnetworks with google private access enabled for network ${subnetwork}`,
-                        LOG_LEVEL.ERROR
-                      );
-                      toast.error(
-                        `There are no subnetworks with google private access enabled for network ${subnetwork}`,
-                        toastifyCustomStyle
-                      );
                     }
                   }
                 } else {
-                  DataprocLoggingService.log(
-                    `No subNetworks found for network ${subnetwork}`,
-                    LOG_LEVEL.ERROR
-                  );
-                  toast.error(
-                    `No subNetworks found  for network ${subnetwork}`,
-                    toastifyCustomStyle
-                  );
+                  const errorMessage = `There are no subnetworks with Google Private Access enabled for network "${subnetwork}"`;
+                  DataprocLoggingService.log(errorMessage, LOG_LEVEL.ERROR);
+                  // Show toast only if it isn't already active
+                  if (!toast.isActive("no-subnetworks")) {
+                    toast.error(errorMessage, {
+                      toastId: "no-subnetworks",
+                      ...toastifyCustomStyle,
+                    });
+                  }
                 }
                 setIsloadingNetwork(false);
                 if (responseResult?.error?.code) {
-                  toast.error(
-                    responseResult?.error?.message,
-                    toastifyCustomStyle
-                  );
+                  const errorMessage = responseResult.error.message;
+
+                  if (!toast.isActive("api-error")) {
+                    toast.error(errorMessage, {
+                      toastId: "api-error",
+                      ...toastifyCustomStyle,
+                    });
+                  }
                 }
               }
             )
@@ -744,15 +740,15 @@ export class RunTimeSerive {
             });
         })
         .catch((err: Error) => {
-          DataprocLoggingService.log(
-            'Error listing subNetworks',
-            LOG_LEVEL.ERROR
-          );
+          DataprocLoggingService.log("Error listing subNetworks", LOG_LEVEL.ERROR);
           setIsloadingNetwork(false);
-          toast.error(
-            `Error listing subNetworks : ${err}`,
-            toastifyCustomStyle
-          );
+          const errorMessage = `Error listing subNetworks: ${err}`;
+          if (!toast.isActive("fetch-error")) {
+            toast.error(errorMessage, {
+              toastId: "fetch-error",
+              ...toastifyCustomStyle,
+            });
+          }
         });
     }
   };

--- a/src/runtime/runtimeService.tsx
+++ b/src/runtime/runtimeService.tsx
@@ -28,7 +28,8 @@ import {
   toastifyCustomStyle,
   loggedFetch,
   authenticatedFetch,
-  jobTimeFormat
+  jobTimeFormat,
+  showToast
 } from '../utils/utils';
 import { toast } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
@@ -711,27 +712,14 @@ export class RunTimeSerive {
                       setSubNetworkSelected(transformedServiceList[0]);
                     } else {
                       const errorMessage = `There are no subnetworks with Google Private Access enabled for network "${subnetwork}"`;
-                      if (!toast.isActive('no-subnetworks')) {
-                        toast.error(errorMessage, {
-                          toastId: 'no-subnetworks-google-access',
-                          ...toastifyCustomStyle
-                        });
-                        DataprocLoggingService.log(
-                          errorMessage,
-                          LOG_LEVEL.ERROR
-                        );
-                      }
+                      showToast(errorMessage, 'no-subnetworks-google-access');
+                      DataprocLoggingService.log(errorMessage, LOG_LEVEL.ERROR);
                     }
                   }
                 } else {
                   const errorMessage = `No subNetworks found  for network ${subnetwork}`;
-                  if (!toast.isActive('no-subnetworks')) {
-                    DataprocLoggingService.log(errorMessage, LOG_LEVEL.ERROR);
-                    toast.error(errorMessage, {
-                      toastId: 'no-subnetworks',
-                      ...toastifyCustomStyle
-                    });
-                  }
+                  showToast(errorMessage, 'no-subnetworks');
+                  DataprocLoggingService.log(errorMessage, LOG_LEVEL.ERROR);
                 }
                 setIsloadingNetwork(false);
                 if (responseResult?.error?.code) {

--- a/src/runtime/runtimeService.tsx
+++ b/src/runtime/runtimeService.tsx
@@ -710,25 +710,28 @@ export class RunTimeSerive {
                     if (transformedServiceList.length > 0) {
                       setSubNetworkSelected(transformedServiceList[0]);
                     } else {
-                     const errorMessage = `There are no subnetworks with Google Private Access enabled for network "${subnetwork}"`;
-                     if (!toast.isActive("no-subnetworks")) {
+                      const errorMessage = `There are no subnetworks with Google Private Access enabled for network "${subnetwork}"`;
+                      if (!toast.isActive('no-subnetworks')) {
                         toast.error(errorMessage, {
-                          toastId: "no-subnetworks-google-access",
-                          ...toastifyCustomStyle,
+                          toastId: 'no-subnetworks-google-access',
+                          ...toastifyCustomStyle
                         });
-                        DataprocLoggingService.log(errorMessage, LOG_LEVEL.ERROR);             
+                        DataprocLoggingService.log(
+                          errorMessage,
+                          LOG_LEVEL.ERROR
+                        );
                       }
                     }
                   }
                 } else {
-                  const errorMessage = `No subNetworks found  for network ${subnetwork}`
-                     if (!toast.isActive("no-subnetworks")) {
-                      DataprocLoggingService.log(errorMessage, LOG_LEVEL.ERROR);
-                        toast.error(errorMessage, {
-                          toastId: "no-subnetworks",
-                          ...toastifyCustomStyle,
-                        });
-                      }
+                  const errorMessage = `No subNetworks found  for network ${subnetwork}`;
+                  if (!toast.isActive('no-subnetworks')) {
+                    DataprocLoggingService.log(errorMessage, LOG_LEVEL.ERROR);
+                    toast.error(errorMessage, {
+                      toastId: 'no-subnetworks',
+                      ...toastifyCustomStyle
+                    });
+                  }
                 }
                 setIsloadingNetwork(false);
                 if (responseResult?.error?.code) {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -451,6 +451,12 @@ export const toastifyCustomStyle: ToastOptions<{}> = {
   theme: 'dark',
   position: toast.POSITION.BOTTOM_CENTER
 };
+export const showToast = (message: string, id?: string) => {
+  if (!id || !toast.isActive(id)) {
+    toast.error(message, { toastId: id, ...toastifyCustomStyle });
+  }
+};
+
 export function assumeNeverHit(_: never): void {}
 export interface IBatchInfoResponse {
   uuid: string;


### PR DESCRIPTION
Updated toast msg with network name for the case where subnetwork is not available.
for ticket - https://taskflow.corp.google.com/workspaces/3706932/work_item/b/384024445?origin=iterations%2F4303053&tab=Details