### PR TITLE
Notebook Templates - change bigframes quickstart url

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -585,7 +585,7 @@ const extension: JupyterFrontEndPlugin<void> = {
 
     const openBigQueryNotebook = async () => {
       const template = {
-        url: 'https://raw.githubusercontent.com/GoogleCloudPlatform/ai-ml-recipes/main/public_datasets/bigframes/bigframes_quickstart.ipynb'
+        url: 'https://raw.githubusercontent.com/GoogleCloudPlatform/ai-ml-recipes/main/notebooks/quickstart/bigframes/bigframes_quickstart.ipynb'
       };
       await NotebookTemplateService.handleClickService(
         template,


### PR DESCRIPTION
Change the plugin reference of the bigframes quickstart url to the new path of the quickstart notebook file located at https://github.com/GoogleCloudPlatform/ai-ml-recipes/blob/main/notebooks/quickstart/bigframes/bigframes_quickstart.ipynb. 