### PR TITLE
Check resource manager api

### DIFF
--- a/dataproc_jupyter_plugin/handlers.py
+++ b/dataproc_jupyter_plugin/handlers.py
@@ -203,7 +203,7 @@ class ResourceManagerHandler(APIHandler):
             )
             self.finish({"status": "OK"})
         except subprocess.CalledProcessError as er:
-            self.finish({"status": "ERROR"})
+            self.finish({"status": "ERROR", "error": str(er)})
 
 
 def setup_handlers(web_app):

--- a/dataproc_jupyter_plugin/handlers.py
+++ b/dataproc_jupyter_plugin/handlers.py
@@ -71,7 +71,7 @@ def configure_gateway_client_url(c, log):
         log.error(
             f"Error constructing the kernel gateway URL; configure your project, region, and credentials using gcloud: {e}"
         )
-        return e
+        return False
 
 
 class DataprocPluginConfig(SingletonConfigurable):
@@ -170,7 +170,7 @@ class ConfigHandler(APIHandler):
             configure_gateway_client_url(self.config, self.log)
             self.finish({"config": ERROR_MESSAGE + "successful"})
         except subprocess.CalledProcessError as er:
-            self.finish({"config": ERROR_MESSAGE + "failed", "error": str(er)})
+            self.finish({"config": ERROR_MESSAGE + "failed"})
 
 
 class UrlHandler(APIHandler):

--- a/dataproc_jupyter_plugin/handlers.py
+++ b/dataproc_jupyter_plugin/handlers.py
@@ -71,7 +71,7 @@ def configure_gateway_client_url(c, log):
         log.error(
             f"Error constructing the kernel gateway URL; configure your project, region, and credentials using gcloud: {e}"
         )
-        return False
+        return e
 
 
 class DataprocPluginConfig(SingletonConfigurable):
@@ -170,7 +170,7 @@ class ConfigHandler(APIHandler):
             configure_gateway_client_url(self.config, self.log)
             self.finish({"config": ERROR_MESSAGE + "successful"})
         except subprocess.CalledProcessError as er:
-            self.finish({"config": ERROR_MESSAGE + "failed"})
+            self.finish({"config": ERROR_MESSAGE + "failed","error": str(er)})
 
 
 class UrlHandler(APIHandler):

--- a/dataproc_jupyter_plugin/handlers.py
+++ b/dataproc_jupyter_plugin/handlers.py
@@ -195,7 +195,7 @@ class LogHandler(APIHandler):
 
 class ResourceManagerHandler(APIHandler):
     @tornado.web.authenticated
-    async def get(self):
+    async def post(self):
         try:
             project = await credentials._gcp_project()
             await async_run_gcloud_subcommand(

--- a/dataproc_jupyter_plugin/tests/test_handlers.py
+++ b/dataproc_jupyter_plugin/tests/test_handlers.py
@@ -211,11 +211,17 @@ async def test_resource_manager_handler_success(jp_fetch, monkeypatch):
         "dataproc_jupyter_plugin.handlers.credentials._gcp_project", mock_gcp_project
     )
 
-    # Mock the gcloud command execution
-    mock_run_gcloud = AsyncMock(return_value="123456789")
-    monkeypatch.setattr(
-        "dataproc_jupyter_plugin.handlers.async_run_gcloud_subcommand", mock_run_gcloud
-    )
+    async def mock_create_subprocess_shell(*args, **kwargs):
+        class MockProcess:
+            def __init__(self):
+                self.returncode = 0
+
+            async def wait(self):
+                pass
+
+        return MockProcess()
+
+    monkeypatch.setattr("asyncio.create_subprocess_shell", mock_create_subprocess_shell)
 
     # Call the handler
     response = await jp_fetch(
@@ -230,11 +236,6 @@ async def test_resource_manager_handler_success(jp_fetch, monkeypatch):
     payload = json.loads(response.body)
     assert payload["status"] == "OK"
 
-    # Verify the correct gcloud command was called
-    mock_run_gcloud.assert_called_once_with(
-        'projects describe my-project-123 --format="value(projectNumber)"'
-    )
-
 
 async def test_resource_manager_handler_error(jp_fetch, monkeypatch):
     # Mock the project ID retrieval
@@ -243,13 +244,38 @@ async def test_resource_manager_handler_error(jp_fetch, monkeypatch):
         "dataproc_jupyter_plugin.handlers.credentials._gcp_project", mock_gcp_project
     )
 
-    # Mock a failure in the gcloud command execution
-    mock_run_gcloud = AsyncMock(
-        side_effect=subprocess.CalledProcessError(1, "gcloud projects describe")
-    )
-    monkeypatch.setattr(
-        "dataproc_jupyter_plugin.handlers.async_run_gcloud_subcommand", mock_run_gcloud
-    )
+    # Mock the subprocess for gcloud command execution to simulate an error
+    async def mock_create_subprocess_shell(*args, **kwargs):
+        class MockProcess:
+            def __init__(self):
+                self.returncode = 1
+
+            async def wait(self):
+                pass
+
+        return MockProcess()
+
+    monkeypatch.setattr("asyncio.create_subprocess_shell", mock_create_subprocess_shell)
+
+    # Mock the error output from the subprocess
+    def mock_tempfile():
+        class MockTempFile:
+            def __enter__(self):
+                self.content = b"Simulated gcloud error"
+                return self
+
+            def __exit__(self, exc_type, exc_val, exc_tb):
+                pass
+
+            def seek(self, pos):
+                pass
+
+            def read(self):
+                return self.content
+
+        return MockTempFile()
+
+    monkeypatch.setattr("tempfile.TemporaryFile", mock_tempfile)
 
     # Call the handler
     response = await jp_fetch(
@@ -263,3 +289,4 @@ async def test_resource_manager_handler_error(jp_fetch, monkeypatch):
     assert response.code == 200
     payload = json.loads(response.body)
     assert payload["status"] == "ERROR"
+    assert payload["error"] == "Simulated gcloud error"

--- a/dataproc_jupyter_plugin/tests/test_handlers.py
+++ b/dataproc_jupyter_plugin/tests/test_handlers.py
@@ -218,7 +218,12 @@ async def test_resource_manager_handler_success(jp_fetch, monkeypatch):
     )
 
     # Call the handler
-    response = await jp_fetch("dataproc-plugin", "checkResourceManager")
+    response = await jp_fetch(
+        "dataproc-plugin",
+        "checkResourceManager",
+        method="POST",
+        allow_nonstandard_methods=True,
+    )
 
     # Validate the response
     assert response.code == 200
@@ -247,7 +252,12 @@ async def test_resource_manager_handler_error(jp_fetch, monkeypatch):
     )
 
     # Call the handler
-    response = await jp_fetch("dataproc-plugin", "checkResourceManager")
+    response = await jp_fetch(
+        "dataproc-plugin",
+        "checkResourceManager",
+        method="POST",
+        allow_nonstandard_methods=True,
+    )
 
     # Validate the response
     assert response.code == 200

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,7 +67,6 @@ import { BigQueryWidget } from './bigQuery/bigQueryWidget';
 import { RunTimeSerive } from './runtime/runtimeService';
 import { Notification } from '@jupyterlab/apputils';
 import { BigQueryService } from './bigQuery/bigQueryService';
-import { error } from 'console';
 import { toast } from 'react-toastify';
 
 const iconDpms = new LabIcon({

--- a/src/index.ts
+++ b/src/index.ts
@@ -368,7 +368,9 @@ const extension: JupyterFrontEndPlugin<void> = {
         const notificationMessage =
           'Cloud Resource Manager API is not enabled. Please enable it to view Dataproc Serverless Notebooks.';
         const enableLink = `https://console.cloud.google.com/apis/library/cloudresourcemanager.googleapis.com?project=${credentials?.project_id}`;
-        const data = await requestAPI('checkResourceManager');
+        const data = await requestAPI('checkResourceManager', {
+          method: 'POST'
+        });
         if ((data as { status: string }).status === 'ERROR') {
           Notification.error(notificationMessage, {
             actions: [

--- a/src/index.ts
+++ b/src/index.ts
@@ -365,6 +365,8 @@ const extension: JupyterFrontEndPlugin<void> = {
 
     async function checkResourceManager() {
       try {
+        const notificationMessage =
+          'Cloud Resource Manager API is not enabled. Please enable the API and restart the instance to view Dataproc Serverless Notebooks.';
         const credentials = await authApi();
         const enableLink = `https://console.cloud.google.com/apis/library/cloudresourcemanager.googleapis.com?project=${credentials?.project_id}`;
         const data = await requestAPI('checkResourceManager', {
@@ -377,7 +379,7 @@ const extension: JupyterFrontEndPlugin<void> = {
               'API [cloudresourcemanager.googleapis.com] not enabled on project'
             )
           ) {
-            Notification.error(error, {
+            Notification.error(notificationMessage, {
               actions: [
                 {
                   label: 'Enable',

--- a/src/index.ts
+++ b/src/index.ts
@@ -372,28 +372,28 @@ const extension: JupyterFrontEndPlugin<void> = {
           method: 'POST'
         });
         const { status, error } = data as { status: string; error?: string };
-
-        if (
-          status === 'ERROR' &&
-          error?.includes(
-            'API [cloudresourcemanager.googleapis.com] not enabled on project'
-          )
-        ) {
-          Notification.error(error, {
-            actions: [
-              {
-                label: 'Enable',
-                callback: () => window.open(enableLink, '_blank'),
-                displayType: 'link'
-              }
-            ],
-            autoClose: false
-          });
-        } else {
-          toast.error(
-            `'Error resourceManager API': ${error}`,
-            toastifyCustomStyle
-          );
+        if (status === 'ERROR') {
+          if (
+            error?.includes(
+              'API [cloudresourcemanager.googleapis.com] not enabled on project'
+            )
+          ) {
+            Notification.error(error, {
+              actions: [
+                {
+                  label: 'Enable',
+                  callback: () => window.open(enableLink, '_blank'),
+                  displayType: 'link'
+                }
+              ],
+              autoClose: false
+            });
+          } else {
+            toast.error(
+              `'Error resourceManager API': ${error}`,
+              toastifyCustomStyle
+            );
+          }
         }
       } catch (error) {
         console.error('Resource manager Api not enabled:', error);

--- a/src/index.ts
+++ b/src/index.ts
@@ -166,8 +166,9 @@ const extension: JupyterFrontEndPlugin<void> = {
     await checkResourceManager();
 
     // Capture the signal
-    eventEmitter.on('dataprocConfigChange', (message: string) => {
+    eventEmitter.on('dataprocConfigChange', async (message: string) => {
       checkAllApisEnabled();
+      await checkResourceManager();
       if (bqFeature.enable_bigquery_integration) {
         loadBigQueryWidget('');
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -389,7 +389,7 @@ const extension: JupyterFrontEndPlugin<void> = {
             });
           } else {
             toast.error(
-              `'Error resourceManager API': ${error}`,
+              `'Error in running gcloud command': ${error}`,
               toastifyCustomStyle
             );
           }

--- a/src/index.ts
+++ b/src/index.ts
@@ -366,7 +366,7 @@ const extension: JupyterFrontEndPlugin<void> = {
       try {
         const credentials = await authApi();
         const notificationMessage =
-          'Cloud Resource Manager API is not enabled. Please enable the API and restart the instance to view Dataproc serverless notebooks.';
+          'Cloud Resource Manager API is not enabled. Please enable the API and restart the instance to view Dataproc Serverless Notebooks.';
         const enableLink = `https://console.cloud.google.com/apis/library/cloudresourcemanager.googleapis.com?project=${credentials?.project_id}`;
         const data = await requestAPI('checkResourceManager', {
           method: 'POST'

--- a/src/index.ts
+++ b/src/index.ts
@@ -366,7 +366,7 @@ const extension: JupyterFrontEndPlugin<void> = {
       try {
         const credentials = await authApi();
         const notificationMessage =
-          'Cloud Resource Manager API is not enabled. Please enable it to view Dataproc Serverless Notebooks.';
+          'Cloud Resource Manager API is not enabled. Please enable the API and restart the instance to view Dataproc serverless notebooks.';
         const enableLink = `https://console.cloud.google.com/apis/library/cloudresourcemanager.googleapis.com?project=${credentials?.project_id}`;
         const data = await requestAPI('checkResourceManager', {
           method: 'POST'

--- a/src/index.ts
+++ b/src/index.ts
@@ -342,10 +342,7 @@ const extension: JupyterFrontEndPlugin<void> = {
         panelDpms.addWidget(new dpmsWidget(app as JupyterLab, themeManager));
         onThemeChanged();
         app.shell.add(panelDpms, 'left', { rank: 1001 });
-        DataprocLoggingService.log(
-          'Metastore is enabled',
-          LOG_LEVEL.INFO
-        );
+        DataprocLoggingService.log('Metastore is enabled', LOG_LEVEL.INFO);
       }
 
       if (enableCloudStorage) {
@@ -360,10 +357,7 @@ const extension: JupyterFrontEndPlugin<void> = {
         );
         onThemeChanged();
         app.shell.add(panelGcs, 'left', { rank: 1002 });
-        DataprocLoggingService.log(
-          'Cloud storage is enabled',
-          LOG_LEVEL.INFO
-        );
+        DataprocLoggingService.log('Cloud storage is enabled', LOG_LEVEL.INFO);
       }
     };
     onSidePanelEnabled();

--- a/src/index.ts
+++ b/src/index.ts
@@ -365,7 +365,8 @@ const extension: JupyterFrontEndPlugin<void> = {
     async function checkResourceManager() {
       try {
         const credentials = await authApi();
-        const notificationMessage = 'The Resource Manager API is not enabled.';
+        const notificationMessage =
+          'Cloud Resource Manager API is not enabled. Please enable it to view Dataproc Serverless Notebooks.';
         const enableLink = `https://console.cloud.google.com/apis/library/cloudresourcemanager.googleapis.com?project=${credentials?.project_id}`;
         const data = await requestAPI('checkResourceManager');
         if ((data as { status: string }).status === 'ERROR') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -163,6 +163,7 @@ const extension: JupyterFrontEndPlugin<void> = {
       panelGcs: Panel | undefined,
       panelDatasetExplorer: Panel | undefined;
     let gcsDrive: GCSDrive | undefined;
+    await checkResourceManager();
 
     // Capture the signal
     eventEmitter.on('dataprocConfigChange', (message: string) => {
@@ -365,6 +366,30 @@ const extension: JupyterFrontEndPlugin<void> = {
       }
     };
     onSidePanelEnabled();
+
+    async function checkResourceManager() {
+      try {
+        const credentials = await authApi();
+        const notificationMessage = 'The Resource Manager API is not enabled.';
+        const enableLink = `https://console.cloud.google.com/apis/library/cloudresourcemanager.googleapis.com?project=${credentials?.project_id}`;
+        const data = await requestAPI('checkResourceManager');
+        if ((data as { status: string }).status === 'ERROR') {
+          Notification.error(notificationMessage, {
+            actions: [
+              {
+                label: 'Enable',
+                callback: () => window.open(enableLink, '_blank'),
+                displayType: 'link'
+              }
+            ],
+            autoClose: false
+          });
+        }
+      } catch (error) {
+        console.error('Resource manager Api not enabled:', error);
+        return [];
+      }
+    }
 
     app.docRegistry.addWidgetExtension(
       'Notebook',


### PR DESCRIPTION
Issue: Users are unable to see dataproc serverless sessions on launcher when the plugin is running on a workbench instance if Resource manager API is not enabled(it is a pre requisite for executing a gcloud command to fetch project details). 

Resolution:  Implemented a function to check if the gcloud describe projects command throws an error on loading the application. In such case a notification will be thrown on load of the application in WBI with a relevant message to enable Resource Manager API. 