### PR TITLE
Fix server config

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -18,5 +18,14 @@ pytest_plugins = ("pytest_jupyter.jupyter_server", )
 
 
 @pytest.fixture
-def jp_server_config(jp_server_config):
-    return {"ServerApp": {"jpserver_extensions": {"dataproc_jupyter_plugin": True}}}
+def jp_server_config(jp_server_config, mock_configure_gateway_client_url_true):
+    return {"ServerApp": {"jpserver_extensions": {"dataproc_jupyter_plugin": True}}, "GatewayClient": {"gateway_retry_interval": 1, "gateway_retry_max": 1, "request_timeout": 1}}
+
+
+# Since the jp_server_config fixture calls configure_gateway_client_url before we have a chance to mock it, we need to mock the result here
+@pytest.fixture(autouse=True)
+def mock_configure_gateway_client_url_true(monkeypatch):
+    monkeypatch.setattr(
+        "dataproc_jupyter_plugin.configure_gateway_client_url",
+        lambda c, log: True,
+    )

--- a/dataproc_jupyter_plugin/__init__.py
+++ b/dataproc_jupyter_plugin/__init__.py
@@ -108,7 +108,6 @@ def _link_jupyter_server_extension(server_app):
     # details and discussion.
     c.GatewayClient.auth_token = "Initial, invalid value"
     
-    return c
 
 
 def _load_jupyter_server_extension(server_app):

--- a/dataproc_jupyter_plugin/__init__.py
+++ b/dataproc_jupyter_plugin/__init__.py
@@ -41,11 +41,11 @@ def _jupyter_server_extension_points():
 
 # Helper method to set a config flag value to be at least the min value.
 # Assumes the config flag takes an int
-def _set_config_with_min_value(config, min_value):
+def _get_config_value_to_assign(config, min_value):
     if not isinstance(config, int):
-        config = min_value
+        return min_value
     else:
-        config = max(config, min_value)
+        return max(config, min_value)
 
 
 def _link_jupyter_server_extension(server_app):
@@ -88,15 +88,15 @@ def _link_jupyter_server_extension(server_app):
     # Dataproc s8s instance start up time, so we want to extend them to be at least the values
     # posted below.
 
-    _set_config_with_min_value(
+    c.GatewayClient.gateway_retry_interval = _get_config_value_to_assign(
         c.GatewayClient.gateway_retry_interval, MIN_GATEWAY_RETRY_INTERVAL)
-    _set_config_with_min_value(
+    c.GatewayClient.gateway_retry_max = _get_config_value_to_assign(
         c.GatewayClient.gateway_retry_max, MIN_GATEWAY_RETRY_MAX)
 
     # The default gateway client request timeout is 42 seconds but the POST request to
     # create a batch can take upwards to 600 seconds, so we want to increase the timeout
     # so that the minimum is 600 seconds.
-    _set_config_with_min_value(
+    c.GatewayClient.request_timeout = _get_config_value_to_assign(
         c.GatewayClient.request_timeout, MIN_GATEWAY_REQUEST_TIMEOUT)
 
     # Version 2.8.0 of the `jupyter_server` package requires the `auth_token`
@@ -107,6 +107,8 @@ def _link_jupyter_server_extension(server_app):
     # See https://github.com/jupyter-server/jupyter_server/issues/1339 for more
     # details and discussion.
     c.GatewayClient.auth_token = "Initial, invalid value"
+    
+    return c
 
 
 def _load_jupyter_server_extension(server_app):

--- a/dataproc_jupyter_plugin/tests/test_handlers.py
+++ b/dataproc_jupyter_plugin/tests/test_handlers.py
@@ -43,6 +43,13 @@ async def test_get_modified_settings(jp_fetch, jp_serverapp):
     assert payload["log_path"] is ""
 
 
+async def test_get_default_config(jp_serverapp):
+    server_config = jp_serverapp.config
+    assert server_config.GatewayClient.gateway_retry_interval == 20
+    assert server_config.GatewayClient.gateway_retry_max == 45
+    assert server_config.GatewayClient.request_timeout == 600
+
+
 async def test_post_config_handler_success(jp_fetch, monkeypatch):
     mock_run_gcloud = AsyncMock()
     mock_clear_cache = Mock()
@@ -221,7 +228,8 @@ async def test_resource_manager_handler_success(jp_fetch, monkeypatch):
 
         return MockProcess()
 
-    monkeypatch.setattr("asyncio.create_subprocess_shell", mock_create_subprocess_shell)
+    monkeypatch.setattr("asyncio.create_subprocess_shell",
+                        mock_create_subprocess_shell)
 
     # Call the handler
     response = await jp_fetch(
@@ -255,7 +263,8 @@ async def test_resource_manager_handler_error(jp_fetch, monkeypatch):
 
         return MockProcess()
 
-    monkeypatch.setattr("asyncio.create_subprocess_shell", mock_create_subprocess_shell)
+    monkeypatch.setattr("asyncio.create_subprocess_shell",
+                        mock_create_subprocess_shell)
 
     # Mock the error output from the subprocess
     def mock_tempfile():


### PR DESCRIPTION
Previous PR did not set the config values properly due to not accounting for Python's pass by assignment mechanics https://github.com/GoogleCloudDataproc/dataproc-jupyter-plugin/pull/237

This fixes that

Also add some tests to validate that we are actually assigning the config values