### PR TITLE
Batches-subnetwork-gpa-error-fix

### DIFF
--- a/src/batches/batchService.tsx
+++ b/src/batches/batchService.tsx
@@ -740,6 +740,8 @@ export class BatchService {
     setIsloadingNetwork: (value: boolean) => void
   ) => {
     setIsloadingNetwork(true);
+    setSubNetworklist([]);
+    setSubNetworkSelected('');
     const credentials = await authApi();
     const { COMPUTE } = await gcpServiceUrls;
 

--- a/src/batches/batchService.tsx
+++ b/src/batches/batchService.tsx
@@ -733,7 +733,7 @@ export class BatchService {
   };
 
   static listSubNetworksAPIService = async (
-    subnetwork: string,
+    network: string,
     setSubNetworklist: (value: string[]) => void,
     setSubNetworkSelected: (value: string) => void,
     batchInfoResponse: any,
@@ -767,17 +767,17 @@ export class BatchService {
         return;
       }
       if (!responseResult.items || responseResult.items.length === 0) {
-        const errorMessage = `No subnetworks found for network "${subnetwork}"`;
+        const errorMessage = `No subnetworks found for network "${network}"`;
         Notification.emit(errorMessage, 'error', { autoClose: 5000 });
         DataprocLoggingService.log(errorMessage, LOG_LEVEL.ERROR);
         setIsloadingNetwork(false);
         return;
       }
       const networkSubnets = responseResult.items.filter(
-        (item: { network: string }) => item.network.split('/')[9] === subnetwork
+        (item: { network: string }) => item.network.split('/')[9] === network
       );
       if (networkSubnets.length === 0) {
-        const errorMessage = `No subnetworks found for network "${subnetwork}"`;
+        const errorMessage = `No subnetworks found for network "${network}"`;
         Notification.emit(errorMessage, 'error', { autoClose: 5000 });
         DataprocLoggingService.log(errorMessage, LOG_LEVEL.ERROR);
         setIsloadingNetwork(false);
@@ -795,7 +795,7 @@ export class BatchService {
         if (transformedServiceList.length > 0) {
           setSubNetworkSelected(transformedServiceList[0]);
         } else {
-          const errorMessage = `There are no subnetworks with Google Private Access enabled for network "${subnetwork}"`;
+          const errorMessage = `There are no subnetworks with Google Private Access enabled for network "${network}"`;
           Notification.emit(errorMessage, 'error', { autoClose: 5000 });
           DataprocLoggingService.log(errorMessage, LOG_LEVEL.ERROR);
         }

--- a/src/batches/batchService.tsx
+++ b/src/batches/batchService.tsx
@@ -795,7 +795,7 @@ export class BatchService {
         if (transformedServiceList.length > 0) {
           setSubNetworkSelected(transformedServiceList[0]);
         } else {
-          const errorMessage = `There are subnetworks for "${subnetwork}" but none have Google Private Access enabled. Please enable Private Google Access for at least one subnetwork.`;
+          const errorMessage = `There are no subnetworks with Google Private Access enabled for network "${subnetwork}"`;
           Notification.emit(errorMessage, 'error', { autoClose: 5000 });
           DataprocLoggingService.log(errorMessage, LOG_LEVEL.ERROR);
         }

--- a/src/batches/batchService.tsx
+++ b/src/batches/batchService.tsx
@@ -744,12 +744,10 @@ export class BatchService {
     setSubNetworkSelected('');
     const credentials = await authApi();
     const { COMPUTE } = await gcpServiceUrls;
-
     if (!credentials) {
       setIsloadingNetwork(false);
       return;
     }
-
     try {
       const response = await loggedFetch(
         `${COMPUTE}/projects/${credentials.project_id}/regions/${credentials.region_id}/subnetworks`,
@@ -760,9 +758,7 @@ export class BatchService {
           }
         }
       );
-
       const responseResult = await response.json();
-
       if (responseResult?.error?.code) {
         Notification.emit(responseResult.error.message, 'error', {
           autoClose: 5000
@@ -770,7 +766,6 @@ export class BatchService {
         setIsloadingNetwork(false);
         return;
       }
-
       if (!responseResult.items || responseResult.items.length === 0) {
         const errorMessage = `No subnetworks found for network "${subnetwork}"`;
         Notification.emit(errorMessage, 'error', { autoClose: 5000 });
@@ -778,11 +773,9 @@ export class BatchService {
         setIsloadingNetwork(false);
         return;
       }
-
       const networkSubnets = responseResult.items.filter(
         (item: { network: string }) => item.network.split('/')[9] === subnetwork
       );
-
       if (networkSubnets.length === 0) {
         const errorMessage = `No subnetworks found for network "${subnetwork}"`;
         Notification.emit(errorMessage, 'error', { autoClose: 5000 });
@@ -790,18 +783,14 @@ export class BatchService {
         setIsloadingNetwork(false);
         return;
       }
-
       const filteredServices = networkSubnets.filter(
         (item: { privateIpGoogleAccess: boolean }) =>
           item.privateIpGoogleAccess === true
       );
-
       const transformedServiceList = filteredServices.map(
         (data: { name: string }) => data.name
       );
-
       setSubNetworklist(transformedServiceList);
-
       if (batchInfoResponse === undefined) {
         if (transformedServiceList.length > 0) {
           setSubNetworkSelected(transformedServiceList[0]);
@@ -811,18 +800,15 @@ export class BatchService {
           DataprocLoggingService.log(errorMessage, LOG_LEVEL.ERROR);
         }
       }
-
       setIsloadingNetwork(false);
     } catch (err) {
       console.error('Error listing subNetworks:', err);
       DataprocLoggingService.log('Error listing subNetworks', LOG_LEVEL.ERROR);
       setIsloadingNetwork(false);
-
       const errorMessage =
         err instanceof Error
           ? `Error listing subNetworks: ${err.message}`
           : 'Error listing subNetworks';
-
       Notification.emit(errorMessage, 'error', { autoClose: 5000 });
     }
   };

--- a/src/batches/createBatch.tsx
+++ b/src/batches/createBatch.tsx
@@ -1043,7 +1043,6 @@ function CreateBatch({
   const handleNetworkChange = async (data: DropdownProps | null) => {
     if (data !== null) {
       setNetworkSelected(data!.toString());
-      await listSubNetworksAPI(data!.toString());
       await handleProjectIdChange(projectId, data!.toString());
     }
   };

--- a/src/runtime/createRunTime.tsx
+++ b/src/runtime/createRunTime.tsx
@@ -816,7 +816,6 @@ function CreateRunTime({
     if (data !== null) {
       setNetworkSelected(data!.toString());
       setSubNetworkSelected(defaultValue);
-      await listSubNetworksAPI(data!.toString());
       await handleProjectIdChange(projectId, data!.toString());
     }
   };


### PR DESCRIPTION
In a new GCP project, there are subnetworks defined for the default network in the project. However, "Private Google Access" is not enabled by default in any of them which is required for any GCP service to use them. User is not able to select a sub-network in the network configuration (e.g. in S8S runtime template creation) and gets an error that there is no sub-network in this project. Updated the error message to :-  turn on Private Google Access if sub-netowrks are defined and Private Google Access has NOT been turned on yet