### PR TITLE
BigQuery Dataset explorer expands flaky issue fix

### DIFF
--- a/ui-tests/tests/bigquery_dataset_explorer.spec.ts
+++ b/ui-tests/tests/bigquery_dataset_explorer.spec.ts
@@ -39,8 +39,8 @@ test('bigquery-dataset-explorer', async ({ page, request }) => {
     await page.waitForSelector('div[role="treeitem"][aria-level="1"]');
     await page.waitForSelector('div[role="treeitem"].caret-icon.down');
 
-    // Wait before clicking "Expand" to ensure consistency and avoid flaky issues 
-    await page.waitForTimeout(4000);
+    // Wait for network activity to settle to ensure consistency and avoid flaky issues
+    await page.waitForLoadState('networkidle');
 
     // Expand the first dataset project. This should always be the `bigquery-public-data` one.
     await page.locator('div[role="treeitem"].caret-icon.down').nth(0).click();


### PR DESCRIPTION
Wait before clicking "Expand" to ensure consistency and avoid flaky issues.