### PR TITLE
Ensuring kernel starting status visibility

### DIFF
--- a/ui-tests/tests/create_and_run_notebook.spec.ts
+++ b/ui-tests/tests/create_and_run_notebook.spec.ts
@@ -36,7 +36,7 @@ test.describe('Create and run notebook', () => {
     // Wait for kernel to be ready (why unknown?  Is this a bug?)
     await page
       .locator('.jp-Notebook-ExecutionIndicator[data-status="starting"]')
-      .waitFor({ timeout: 10000 });
+      .waitFor({ timeout: 30000 });
 
     await firstCodeBox.click();
     await firstCodeBox.fill("print('test output')");


### PR DESCRIPTION
Increased wait time to ensure kernel  starting status is displayed to avoid inconsistent failure issue.