### PR TITLE
Metastore Section Enhancements and Spark Icon Revert

### DIFF
--- a/src/runtime/createRunTime.tsx
+++ b/src/runtime/createRunTime.tsx
@@ -1274,8 +1274,8 @@ function CreateRunTime({
         metastoreType === 'biglake' &&
         metastoreDetailUpdated.forEach((label: string) => {
           const firstColonIndex = label.indexOf(':');
-          const key = label.substring(0, firstColonIndex);
-          const value = label.substring(firstColonIndex + 1);
+          const key = firstColonIndex === -1 ? label : label.substring(0, firstColonIndex);
+          const value = firstColonIndex === -1 ? '' : label.substring(firstColonIndex + 1);
           propertyObject[key] = value;
         });
         propertyDetailUpdated.forEach((label: string) => {

--- a/src/runtime/createRunTime.tsx
+++ b/src/runtime/createRunTime.tsx
@@ -226,10 +226,11 @@ function CreateRunTime({
   useEffect(() => {
     if (metastoreType === 'biglake') {
       const metaStorePropertiesList = metastoreDetail.length > 0 ? metastoreDetail : META_STORE_DEFAULT;
-      const warehouseProperty = 'spark.sql.catalog.biglake.warehouse:';
+      const warehousePropertyPrefix = 'spark.sql.catalog.';
+      const warehousePropertySuffix = '.warehouse:';
       const metaStoreProperties = metaStorePropertiesList.map(property => {
-        if (property.startsWith(warehouseProperty)) {
-          return warehouseProperty + dataWarehouseDir;
+        if (property.startsWith(warehousePropertyPrefix) && property.includes(warehousePropertySuffix)) {
+          return property.split(":")[0] + ":" + dataWarehouseDir;
         }
         return property;
       });

--- a/src/runtime/createRunTime.tsx
+++ b/src/runtime/createRunTime.tsx
@@ -162,6 +162,7 @@ function CreateRunTime({
     gpu: [],
     metastore: []
   });
+  const [metastoreKeyValidation, setMetastoreKeyValidation] = useState<number[]>([]);
   const [duplicateKeyError, setDuplicateKeyError] = useState(-1);
   const [labelDetail, setLabelDetail] = useState(key);
   const [labelDetailUpdated, setLabelDetailUpdated] = useState(value);
@@ -225,7 +226,7 @@ function CreateRunTime({
   useEffect(() => {
     if (metastoreType === 'biglake') {
       const metaStorePropertiesList = metastoreDetail.length > 0 ? metastoreDetail : META_STORE_DEFAULT;
-      const warehouseProperty = 'spark.sql.catalog.iceberg_catalog.warehouse:';
+      const warehouseProperty = 'spark.sql.catalog.biglake.warehouse:';
       const metaStoreProperties = metaStorePropertiesList.map(property => {
         if (property.startsWith(warehouseProperty)) {
           return warehouseProperty + dataWarehouseDir;
@@ -461,6 +462,7 @@ function CreateRunTime({
     setVersionSelected(version);
     setMetastoreType(metastore);
     setVersionBiglakeValidation(metastore === 'biglake' && version !== '2.3');
+    setMetastoreKeyValidation([]);
   };
 
   const renderLoadingLabel = (label: string, isLoading: boolean) => {
@@ -636,7 +638,7 @@ function CreateRunTime({
                 META_STORE_DEFAULT.some(item => {
                   const [itemKey] = item.split(':');
                   return itemKey === property.split(':')[0];
-                })
+                }) || property.startsWith('spark.sql.catalog.')
               ) {
                 metaStoreDetailList.push(property);
               } else {
@@ -652,9 +654,9 @@ function CreateRunTime({
             setMetastoreDetailUpdated(metaStoreDetailList);
             if (metaStoreDetailList.length > 0) {
               setMetastoreType('biglake');
-              const warehouseProperty = metaStoreDetailList.find(property =>
-                property.startsWith('spark.sql.catalog.iceberg_catalog.warehouse:')
-              );
+              const warehouseProperty = (metaStoreDetailList[2] && metaStoreDetailList[2].startsWith('spark.sql.catalog.') && metaStoreDetailList[2].split(':').length === 3)
+                ? metaStoreDetailList[2]
+                : null; 
               if (warehouseProperty) {
                 const firstColonIndex = warehouseProperty.indexOf(':');
                 const warehouseUrl = warehouseProperty.substring(firstColonIndex + 1);
@@ -1051,6 +1053,7 @@ function CreateRunTime({
       sparkValueValidation.resourceallocation.length !== 0 ||
       sparkValueValidation.autoscaling.length !== 0 ||
       sparkValueValidation.gpu.length !== 0 ||
+      metastoreKeyValidation.length !== 0 ||
       displayNameSelected === '' ||
       runTimeSelected === '' ||
       desciptionSelected === '' ||
@@ -2427,6 +2430,8 @@ function CreateRunTime({
                       setSparkValueValidation={setSparkValueValidation}
                       sparkSection="metastore"
                       setGpuDetailChangeDone={setGpuDetailChangeDone}
+                      metastoreKeyValidation={metastoreKeyValidation}
+                      setMetastoreKeyValidation={setMetastoreKeyValidation}
                     />
                   )}
                 </>

--- a/src/runtime/sparkProperties.tsx
+++ b/src/runtime/sparkProperties.tsx
@@ -102,87 +102,55 @@ function SparkProperties({
           /*
             allowed aplhanumeric and spaces and underscores values
           */
-          if (MEMORY_RELATED_PROPERTIES.includes(data.split(':')[0])) {
+          let label = data.split(':')[0];
+          if (MEMORY_RELATED_PROPERTIES.includes(label)) {
             const regex = /^(0*[1-9][0-9]*)(m|g|t)$/i;
 
-            if (value.search(regex) === -1) {
-              updateErrorIndexes(index, true);
-            } else {
-              updateErrorIndexes(index, false);
-            }
-          } else if (DISK_RELATED_PROPERTIES.includes(data.split(':')[0])) {
+            const isError = value.search(regex) === -1;
+            updateErrorIndexes(index, isError);
+          } else if (DISK_RELATED_PROPERTIES.includes(label)) {
             const regex = /^(0*[1-9][0-9]*)(k|m|g|t)$/i;
 
-            if (value.search(regex) === -1) {
-              updateErrorIndexes(index, true);
-            } else {
-              updateErrorIndexes(index, false);
-            }
-          } else if (CORE_RELATED_PROPERTIES.includes(data.split(':')[0])) {
-            if (
+            const isError = value.search(regex) === -1;
+            updateErrorIndexes(index, isError);
+          } else if (CORE_RELATED_PROPERTIES.includes(label)) {
+            const isError =
               value.includes('.') ||
               !Number.isInteger(Number(value)) ||
-              Number(value) <= 0
-            ) {
-              updateErrorIndexes(index, true);
-            } else {
-              updateErrorIndexes(index, false);
-            }
-          } else if (EXECUTOR_RELATED_PROPERTIES.includes(data.split(':')[0])) {
-            if (
+              Number(value) <= 0;
+            updateErrorIndexes(index, isError);
+          } else if (EXECUTOR_RELATED_PROPERTIES.includes(label)) {
+            const isError =
               value.includes('.') ||
               !Number.isInteger(Number(value)) ||
               Number(value) < 2 ||
-              Number(value) > 2000
-            ) {
-              updateErrorIndexes(index, true);
-            } else {
-              updateErrorIndexes(index, false);
-            }
-          } else if (
-            data.split(':')[0] === 'spark.dynamicAllocation.initialExecutors'
-          ) {
-            if (
+              Number(value) > 2000;
+            updateErrorIndexes(index, isError);
+          } else if (label === 'spark.dynamicAllocation.initialExecutors') {
+            const isError =
               value.includes('.') ||
               !Number.isInteger(Number(value)) ||
               Number(value) < 2 ||
-              Number(value) > 500
-            ) {
-              updateErrorIndexes(index, true);
-            } else {
-              updateErrorIndexes(index, false);
-            }
-          } else if (
-            data.split(':')[0] === 'spark.dynamicAllocation.minExecutors'
-          ) {
-            if (
+              Number(value) > 500;
+            updateErrorIndexes(index, isError);
+          } else if (label === 'spark.dynamicAllocation.minExecutors') {
+            const isError =
               value.includes('.') ||
               !Number.isInteger(Number(value)) ||
-              Number(value) < 2
-            ) {
-              updateErrorIndexes(index, true);
-            } else {
-              updateErrorIndexes(index, false);
-            }
-          } else if (
-            data.split(':')[0] ===
-            'spark.dynamicAllocation.executorAllocationRatio'
-          ) {
-            if (
+              Number(value) < 2;
+            updateErrorIndexes(index, isError);
+          } else if (label === 'spark.dynamicAllocation.executorAllocationRatio') {
+            const isError =
               value.length === 0 ||
               Number.isNaN(Number(value)) ||
               Number(value) < 0 ||
-              Number(value) > 1
-            ) {
-              updateErrorIndexes(index, true);
-            } else {
-              updateErrorIndexes(index, false);
-            }
+              Number(value) > 1;
+            updateErrorIndexes(index, isError);
           }
           /*
             value is split from labels
             Example:"client:dataproc_jupyter_plugin"
-            */
+          */
           let sparkProperties = data.split(':');
           sparkProperties[1] = value.trim();
           data = sparkProperties[0] + ':' + sparkProperties[1];

--- a/src/runtime/sparkProperties.tsx
+++ b/src/runtime/sparkProperties.tsx
@@ -238,7 +238,6 @@ function SparkProperties({
                         onChange={e =>
                           handleEditLabel(sparkSection,e.target.value, index, 'key')
                         }
-                        defaultValue={labelSplit[0]}
                         Label={`Key ${index + 1}*`}
                         value={labelDetailUpdated[index] ? labelDetailUpdated[index].substring(0,labelDetailUpdated[index].indexOf(':')) : ''}
                       />

--- a/src/utils/const.ts
+++ b/src/utils/const.ts
@@ -221,9 +221,9 @@ export const AUTO_SCALING_DEFAULT = [
 ];
 
 export const META_STORE_DEFAULT = [
-  'spark.sql.catalog.iceberg_catalog:org.apache.iceberg.spark.SparkCatalog',
-  'spark.sql.catalog.iceberg_catalog.type:hadoop',
-  'spark.sql.catalog.iceberg_catalog.warehouse:'
+  'spark.sql.catalog.biglake:org.apache.iceberg.spark.SparkCatalog',
+  'spark.sql.catalog.biglake.type:hadoop',
+  'spark.sql.catalog.biglake.warehouse:'
 ]
 
 export const META_STORE_TYPES = [

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -17,7 +17,6 @@
 
 import { LabIcon } from '@jupyterlab/ui-components';
 import pysparkLogo from '../../third_party/icons/pyspark_logo.svg';
-import pySparkDarkLogo from '../../third_party/icons/pyspark_dark_icon.svg'
 import pythonLogo from '../../third_party/icons/python_logo.svg';
 import scalaLogo from '../../third_party/icons/scala_logo.svg';
 import sparkrLogo from '../../third_party/icons/sparkr_logo.svg';
@@ -344,10 +343,6 @@ const iconPysparkLogo = new LabIcon({
   name: 'launcher:pyspark-logo-icon',
   svgstr: pysparkLogo
 });
-const iconPysparkDarkLogo = new LabIcon({
-  name: 'launcher:pyspark-dark-logo-icon',
-  svgstr: pySparkDarkLogo
-})
 const iconPythonLogo = new LabIcon({
   name: 'launcher:python-logo-icon',
   svgstr: pythonLogo
@@ -362,9 +357,6 @@ const iconScalaLogo = new LabIcon({
 });
 
 export const iconDisplay = (kernelType: KernelSpecAPI.ISpecModel,themeManager: IThemeManager) => {
-  const isLightTheme = themeManager.theme
-        ? themeManager.isLight(themeManager.theme)
-        : true;
   const kernalName = kernelType?.name || '';
   const kernalLanguage = kernelType?.language || '';
   
@@ -381,7 +373,7 @@ export const iconDisplay = (kernelType: KernelSpecAPI.ISpecModel,themeManager: I
     if (kernalLanguage === 'scala') {
       return iconScalaLogo;
     }
-    return isLightTheme ? iconPysparkLogo : iconPysparkDarkLogo;
+    return iconPysparkLogo;
   }
   
   return iconPythonLogo;


### PR DESCRIPTION
MetaStore Section Changes: 
   * replaced iceberg_catalog with biglake
   * keys are editable
   * Validation for key section added

Dataproc Serverless Spark:
   * Dark theme Icon has been reverted.