### PR TITLE
Filter jupyter templates as part of runtime templates listing

### DIFF
--- a/src/runtime/runtimeService.tsx
+++ b/src/runtime/runtimeService.tsx
@@ -158,8 +158,8 @@ export class RunTimeSerive {
   setPollingDisable: (value: boolean) => void,
   setEnableLink: (value: string) => void,
   nextPageToken?: string,
-  previousRuntimeTemplatesList?: object,
-  previousRuntimeTemplatesAllList?: object
+  previousRuntimeTemplatesList?:  ISessionTemplateDisplay[],
+  previousRuntimeTemplatesAllList?: ISessionTemplate[]
 ) => {
   try {
     const pageToken = nextPageToken ?? '';
@@ -181,18 +181,15 @@ export class RunTimeSerive {
       
       const jupyterSessionTemplates = formattedResponse.sessionTemplates.filter(
         (template: ISessionTemplate) => template.jupyterSession
-      );
-
-      let runtimeTemplatesListNew = jupyterSessionTemplates; 
-      
-      runtimeTemplatesListNew.sort(
+      );      
+      jupyterSessionTemplates.sort(
         (a: { updateTime: string }, b: { updateTime: string }) => {
           const dateA = new Date(a.updateTime);
           const dateB = new Date(b.updateTime);
           return Number(dateB) - Number(dateA);
         }
       );
-      transformRuntimeTemplatesListData = runtimeTemplatesListNew.map(
+      transformRuntimeTemplatesListData = jupyterSessionTemplates.map(
         (data: ISessionTemplate) => {
 
           const startTimeDisplay = data.updateTime
@@ -201,8 +198,7 @@ export class RunTimeSerive {
 
           let displayName = '';
 
-          // We know data.jupyterSession exists, so we can safely access it
-          if (data.jupyterSession && data.jupyterSession.displayName) {
+          if (data.jupyterSession.displayName) {
             displayName = data.jupyterSession.displayName;
           }
           


### PR DESCRIPTION
Currently dataproc jupyter plugin lists both jupyter and spark connect templates as part of runtime templates listing.
Modify the code to diplay only jupyter templates as Jupyter lab does not support spark connect templates at this point