### PR TITLE
fix: bigQuery enable Api link

### DIFF
--- a/src/bigQuery/bigQueryWidget.tsx
+++ b/src/bigQuery/bigQueryWidget.tsx
@@ -48,6 +48,7 @@ import { BigQueryTableWrapper } from './bigQueryTableInfoWrapper';
 import { DataprocWidget } from '../controls/DataprocWidget';
 import { checkConfig, handleDebounce } from '../utils/utils';
 import LoginErrorComponent from '../utils/loginErrorComponent';
+import { BIGQUERY_API_URL } from '../utils/const';
 
 const iconDatasets = new LabIcon({
   name: 'launcher:datasets-icon',
@@ -1072,7 +1073,7 @@ const BigQueryComponent = ({
                 Bigquery API is not enabled for this project.
                 Please{' '}
                 <a
-                  href={`https://console.cloud.google.com/apis/library/bigquery.googleapis.com?project=${projectName}`}
+                  href={`${BIGQUERY_API_URL}?project=${projectName}`}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="link-class"

--- a/src/bigQuery/bigQueryWidget.tsx
+++ b/src/bigQuery/bigQueryWidget.tsx
@@ -1072,7 +1072,7 @@ const BigQueryComponent = ({
                 Bigquery API is not enabled for this project.
                 Please{' '}
                 <a
-                  href={`https://pantheon.corp.google.com/apis/library/bigquery.googleapis.com?project=${projectName}`}
+                  href={`https://console.cloud.google.com/apis/library/bigquery.googleapis.com?project=${projectName}`}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="link-class"

--- a/src/utils/const.ts
+++ b/src/utils/const.ts
@@ -299,3 +299,5 @@ export const BIGQUERY_SERVICE_NAME = 'bigquery.googleapis.com';
 export const PAGE_SIZE = 50;
 
 export const DEFAULT_PUBLIC_PROJECT_ID = 'bigquery-public-data';
+
+export const BIGQUERY_API_URL = 'https://console.cloud.google.com/apis/library/bigquery.googleapis.com';


### PR DESCRIPTION
enable bigquery Api link is updated to console.cloud.google.com link 