### PR TITLE
Remove the `project_number` field from the credentials handler response.

### DIFF
--- a/dataproc_jupyter_plugin/credentials.py
+++ b/dataproc_jupyter_plugin/credentials.py
@@ -14,7 +14,6 @@
 
 import logging
 
-import cachetools
 from google.cloud.jupyter_config.config import (
     async_get_gcloud_config,
     async_run_gcloud_subcommand,

--- a/dataproc_jupyter_plugin/tests/mocks.py
+++ b/dataproc_jupyter_plugin/tests/mocks.py
@@ -21,7 +21,6 @@ from dataproc_jupyter_plugin import credentials
 async def mock_credentials():
     return {
         "project_id": "credentials-project",
-        "project_number": 12345,
         "region_id": "mock-region",
         "access_token": "mock-token",
         "config_error": 0,

--- a/dataproc_jupyter_plugin/tests/test_credentials.py
+++ b/dataproc_jupyter_plugin/tests/test_credentials.py
@@ -48,7 +48,6 @@ class TestGetCached(unittest.IsolatedAsyncioTestCase):
     async def test_get_cached(self):
         cached = await credentials.get_cached()
         self.assertEqual(cached["project_id"], "")
-        self.assertEqual(cached["project_number"], None)
         self.assertEqual(cached["access_token"], "example-token")
         self.assertEqual(cached["region_id"], "example-region")
         self.assertEqual(cached["login_error"], 0)


### PR DESCRIPTION
This was being populated by issuing a call to the GCP resource manager API on every request to the `/dataproc-plugin/credentials` URL.

That caused every single such request to take at least rougly 1 second.

On top of that, this field was never being used anywhere.

It's not clear why this was ever introduced; it might have been intended to be used to report configuration issues at startup, but it was never actually used, and since it was added the frequency of calls to the `/dataproc-plugin/credentials` endpoint has significantly increased.

As a result, this dead/unused code was now causing significant delays when trying to use the plugin.