### PR TITLE
Fix regional datasets not showing up in Data Explorer

### DIFF
--- a/dataproc_jupyter_plugin/controllers/bigquery.py
+++ b/dataproc_jupyter_plugin/controllers/bigquery.py
@@ -54,9 +54,8 @@ class DatasetController(APIHandler):
         try:
             page_token = self.get_argument("pageToken")
             project_id = self.get_argument("project_id")
-            location = self.get_argument("location", default="us").lower()
             bq_client = await bigquery_client.get_client(self.log)
-            dataset_list = await bq_client.list_datasets(page_token, project_id, location)
+            dataset_list = await bq_client.list_datasets(page_token, project_id)
             self.finish(json.dumps(dataset_list))
         except Exception as e:
             self.log.exception("Error fetching datasets")

--- a/dataproc_jupyter_plugin/services/bigquery.py
+++ b/dataproc_jupyter_plugin/services/bigquery.py
@@ -87,10 +87,15 @@ class Client:
                     if response.status == 200:
                         resp = await response.json()
                         # Map Search results to the format expected by the frontend
-                        entries = [r.get("dataplexEntry") for r in resp.get("results", [])]
+                        results = resp.get("results") or []
+                        entries = [
+                            r.get("dataplexEntry")
+                            for r in results
+                            if r.get("dataplexEntry")
+                        ]
                         return {
                             "entries": entries,
-                            "nextPageToken": resp.get("nextPageToken")
+                            "nextPageToken": resp.get("nextPageToken"),
                         }
                     else:
                         raise Exception(
@@ -222,8 +227,11 @@ class Client:
                     ) as response:
                         if response.status == 200:
                             resp = await response.json()
-                            if "results" in resp:
-                                search_results.extend(resp["results"])
+                            results = resp.get("results")
+                            if results:
+                                search_results.extend(
+                                    [r for r in results if r.get("dataplexEntry")]
+                                )
 
                             if "nextPageToken" in resp:
                                 payload["pageToken"] = resp["nextPageToken"]

--- a/dataproc_jupyter_plugin/services/bigquery.py
+++ b/dataproc_jupyter_plugin/services/bigquery.py
@@ -48,7 +48,7 @@ class Client:
             "Authorization": f"Bearer {self._access_token}",
         }
 
-    async def list_datasets(self, page_token, project_id, location):
+    async def list_datasets(self, page_token, project_id):
         try:
             if project_id == BQ_PUBLIC_DATASET_PROJECT_ID:
                 # Use BigQuery API for public datasets

--- a/dataproc_jupyter_plugin/services/bigquery.py
+++ b/dataproc_jupyter_plugin/services/bigquery.py
@@ -56,25 +56,46 @@ class Client:
                 api_endpoint = f"{bigquery_url}bigquery/v2/projects/{BQ_PUBLIC_DATASET_PROJECT_ID}/datasets?maxResults={PAGE_SIZE_LIMIT}"
                 if page_token:
                     api_endpoint += f"&pageToken={page_token}"
+                async with self.client_session.get(
+                    api_endpoint, headers=self.create_headers()
+                ) as response:
+                    if response.status == 200:
+                        resp = await response.json()
+                        return resp
+                    else:
+                        raise Exception(
+                            f"Error response from BigQuery: {response.reason} {await response.text()}"
+                        )
             else:
-                # Use Dataplex API for user-specific datasets
+                # Use Dataplex Search API for user-specific datasets to get all regions
                 dataplex_url = await urls.gcp_service_url(DATAPLEX_SERVICE_NAME)
-                api_endpoint = (
-                    f"{dataplex_url}/v1/projects/{project_id}/locations/{location}/entryGroups/@bigquery/entries?filter=entry_type=projects/{BASE_PROJECT_ID}/locations/global/entryTypes/bigquery-dataset&pageSize={PAGE_SIZE_LIMIT}"
-                )
+                api_endpoint = f"{dataplex_url}v1/projects/{self.project_id}/locations/global:searchEntries"
+
+                payload = {
+                    "query": f"system=BIGQUERY type=DATASET projectid={project_id}",
+                    "pageSize": PAGE_SIZE_LIMIT,
+                }
                 if page_token:
-                    api_endpoint += f"&pageToken={page_token}"
-            
-            async with self.client_session.get(
-                api_endpoint, headers=self.create_headers()
-            ) as response:
-                if response.status == 200:
-                    resp = await response.json()
-                    return resp
-                else:
-                    raise Exception(
-                        f"Error response from BigQuery: {response.reason} {await response.text()}"
-                    )
+                    payload["pageToken"] = page_token
+
+                headers = self.create_headers()
+                headers["X-Goog-User-Project"] = self.project_id
+
+                async with self.client_session.post(
+                    api_endpoint, headers=headers, json=payload
+                ) as response:
+                    if response.status == 200:
+                        resp = await response.json()
+                        # Map Search results to the format expected by the frontend
+                        entries = [r.get("dataplexEntry") for r in resp.get("results", [])]
+                        return {
+                            "entries": entries,
+                            "nextPageToken": resp.get("nextPageToken")
+                        }
+                    else:
+                        raise Exception(
+                            f"Error response from Dataplex: {response.reason} {await response.text()}"
+                        )
         except Exception as e:
             self.log.exception("Error fetching datasets list")
             return {"error": str(e)}

--- a/dataproc_jupyter_plugin/tests/test_bigquery.py
+++ b/dataproc_jupyter_plugin/tests/test_bigquery.py
@@ -104,8 +104,13 @@ async def test_list_datasets_user_specific(
 ):
     mock_response = AsyncMock()
     mock_response.status = 200
-    mock_response.json.return_value = {"entries": ["user_dataset1", "user_dataset2"]}
-    mock_client_session.get.return_value.__aenter__.return_value = mock_response
+    mock_response.json.return_value = {
+        "results": [
+            {"dataplexEntry": "user_dataset1"},
+            {"dataplexEntry": "user_dataset2"}
+        ]
+    }
+    mock_client_session.post.return_value.__aenter__.return_value = mock_response
 
     client = Client(mock_credentials, mock_log, mock_client_session)
     result = await client.list_datasets(
@@ -114,9 +119,18 @@ async def test_list_datasets_user_specific(
         location="us"
     )
 
-    expected_url = f"https://dataplex.googleapis.com//v1/projects/my-project-123/locations/us/entryGroups/@bigquery/entries?filter=entry_type=projects/{BASE_PROJECT_ID}/locations/global/entryTypes/bigquery-dataset&pageSize={PAGE_SIZE_LIMIT}"
-    mock_client_session.get.assert_called_once_with(expected_url, headers=client.create_headers())
-    assert result == {"entries": ["user_dataset1", "user_dataset2"]}
+    expected_url = f"https://dataplex.googleapis.com/v1/projects/mock-project-id/locations/global:searchEntries"
+    expected_payload = {
+        "query": f"system=BIGQUERY type=DATASET projectid=my-project-123",
+        "pageSize": PAGE_SIZE_LIMIT,
+    }
+    expected_headers = client.create_headers()
+    expected_headers["X-Goog-User-Project"] = "mock-project-id"
+    
+    mock_client_session.post.assert_called_once_with(
+        expected_url, headers=expected_headers, json=expected_payload
+    )
+    assert result == {"entries": ["user_dataset1", "user_dataset2"], "nextPageToken": None}
 
 @pytest.mark.asyncio
 async def test_list_datasets_api_error(
@@ -126,7 +140,7 @@ async def test_list_datasets_api_error(
     mock_response.status = 403
     mock_response.reason = "Forbidden"
     mock_response.text.return_value = "Permission denied"
-    mock_client_session.get.return_value.__aenter__.return_value = mock_response
+    mock_client_session.post.return_value.__aenter__.return_value = mock_response
 
     client = Client(mock_credentials, mock_log, mock_client_session)
     result = await client.list_datasets(
@@ -135,7 +149,7 @@ async def test_list_datasets_api_error(
         location="us"
     )
 
-    assert result["error"] == "Error response from BigQuery: Forbidden Permission denied"
+    assert result["error"] == "Error response from Dataplex: Forbidden Permission denied"
     mock_log.exception.assert_called_once_with("Error fetching datasets list")
 
 async def test_list_tables(monkeypatch, jp_fetch):

--- a/dataproc_jupyter_plugin/tests/test_bigquery.py
+++ b/dataproc_jupyter_plugin/tests/test_bigquery.py
@@ -90,8 +90,7 @@ async def test_list_datasets_public_with_page_token(
     client = Client(mock_credentials, mock_log, mock_client_session)
     result = await client.list_datasets(
         page_token="next-page",
-        project_id=BQ_PUBLIC_DATASET_PROJECT_ID,
-        location="us"
+        project_id=BQ_PUBLIC_DATASET_PROJECT_ID
     )
 
     expected_url = f"https://bigquery.googleapis.com/bigquery/v2/projects/{BQ_PUBLIC_DATASET_PROJECT_ID}/datasets?maxResults={PAGE_SIZE_LIMIT}&pageToken=next-page"
@@ -115,8 +114,7 @@ async def test_list_datasets_user_specific(
     client = Client(mock_credentials, mock_log, mock_client_session)
     result = await client.list_datasets(
         page_token=None,
-        project_id="my-project-123",
-        location="us"
+        project_id="my-project-123"
     )
 
     expected_url = f"https://dataplex.googleapis.com/v1/projects/mock-project-id/locations/global:searchEntries"
@@ -145,8 +143,7 @@ async def test_list_datasets_api_error(
     client = Client(mock_credentials, mock_log, mock_client_session)
     result = await client.list_datasets(
         page_token=None,
-        project_id="my-project-123",
-        location="us"
+        project_id="my-project-123"
     )
 
     assert result["error"] == "Error response from Dataplex: Forbidden Permission denied"

--- a/dataproc_jupyter_plugin/tests/test_bigquery_edge_cases.py
+++ b/dataproc_jupyter_plugin/tests/test_bigquery_edge_cases.py
@@ -47,8 +47,7 @@ async def test_list_datasets_null_results(
     client = Client(mock_credentials, mock_log, mock_client_session)
     result = await client.list_datasets(
         page_token=None,
-        project_id="my-project-123",
-        location="us"
+        project_id="my-project-123"
     )
     assert result == {"entries": [], "nextPageToken": None}
 
@@ -71,8 +70,7 @@ async def test_list_datasets_filter_missing_dataplex_entry(
     client = Client(mock_credentials, mock_log, mock_client_session)
     result = await client.list_datasets(
         page_token=None,
-        project_id="my-project-123",
-        location="us"
+        project_id="my-project-123"
     )
     assert result["entries"] == [{"name": "entry1"}]
 

--- a/dataproc_jupyter_plugin/tests/test_bigquery_edge_cases.py
+++ b/dataproc_jupyter_plugin/tests/test_bigquery_edge_cases.py
@@ -1,0 +1,110 @@
+
+import pytest
+import aiohttp
+from unittest.mock import AsyncMock, Mock, patch
+from dataproc_jupyter_plugin.services.bigquery import Client
+from dataproc_jupyter_plugin.commons.constants import (
+    BIGQUERY_SERVICE_NAME,
+    DATAPLEX_SERVICE_NAME,
+    PAGE_SIZE_LIMIT
+)
+
+@pytest.fixture
+def mock_credentials():
+    return {
+        "access_token": "mock-token",
+        "project_id": "mock-project-id",
+        "region_id": "us-central1"
+    }
+
+@pytest.fixture
+def mock_log():
+    return Mock()
+
+@pytest.fixture
+def mock_client_session():
+    return AsyncMock(spec=aiohttp.ClientSession)
+
+@pytest.fixture
+def mock_gcp_urls():
+    with patch("dataproc_jupyter_plugin.urls.gcp_service_url") as mock_url:
+        mock_url.side_effect = lambda service_name: {
+            BIGQUERY_SERVICE_NAME: "https://bigquery.googleapis.com/",
+            DATAPLEX_SERVICE_NAME: "https://dataplex.googleapis.com/"
+        }.get(service_name)
+        yield mock_url
+
+@pytest.mark.asyncio
+async def test_list_datasets_null_results(
+    mock_credentials, mock_log, mock_client_session, mock_gcp_urls
+):
+    """Test that list_datasets handles null results from Dataplex API without TypeError."""
+    mock_response = AsyncMock()
+    mock_response.status = 200
+    mock_response.json.return_value = {"results": None}
+    mock_client_session.post.return_value.__aenter__.return_value = mock_response
+
+    client = Client(mock_credentials, mock_log, mock_client_session)
+    result = await client.list_datasets(
+        page_token=None,
+        project_id="my-project-123",
+        location="us"
+    )
+    assert result == {"entries": [], "nextPageToken": None}
+
+@pytest.mark.asyncio
+async def test_list_datasets_filter_missing_dataplex_entry(
+    mock_credentials, mock_log, mock_client_session, mock_gcp_urls
+):
+    """Test that list_datasets filters out results missing dataplexEntry."""
+    mock_response = AsyncMock()
+    mock_response.status = 200
+    mock_response.json.return_value = {
+        "results": [
+            {"dataplexEntry": {"name": "entry1"}},
+            {"somethingElse": "no-dataplex-entry"},
+            {"dataplexEntry": None}
+        ]
+    }
+    mock_client_session.post.return_value.__aenter__.return_value = mock_response
+
+    client = Client(mock_credentials, mock_log, mock_client_session)
+    result = await client.list_datasets(
+        page_token=None,
+        project_id="my-project-123",
+        location="us"
+    )
+    assert result["entries"] == [{"name": "entry1"}]
+
+@pytest.mark.asyncio
+async def test_bigquery_search_null_results(
+    mock_credentials, mock_log, mock_client_session, mock_gcp_urls
+):
+    """Test that bigquery_search handles null results from Dataplex API."""
+    mock_response = AsyncMock()
+    mock_response.status = 200
+    mock_response.json.return_value = {"results": None}
+    mock_client_session.post.return_value.__aenter__.return_value = mock_response
+
+    client = Client(mock_credentials, mock_log, mock_client_session)
+    result = await client.bigquery_search("query", "type", "system", ["p1"])
+    assert result == {}
+
+@pytest.mark.asyncio
+async def test_bigquery_search_filter_missing_dataplex_entry(
+    mock_credentials, mock_log, mock_client_session, mock_gcp_urls
+):
+    """Test that bigquery_search filters out results missing dataplexEntry."""
+    mock_response = AsyncMock()
+    mock_response.status = 200
+    mock_response.json.return_value = {
+        "results": [
+            {"dataplexEntry": {"name": "entry1"}},
+            {"somethingElse": "no-dataplex-entry"}
+        ]
+    }
+    mock_client_session.post.return_value.__aenter__.return_value = mock_response
+
+    client = Client(mock_credentials, mock_log, mock_client_session)
+    result = await client.bigquery_search("query", "type", "system", ["p1"])
+    assert result["results"] == [{"dataplexEntry": {"name": "entry1"}}]

--- a/src/bigQuery/bigQueryService.tsx
+++ b/src/bigQuery/bigQueryService.tsx
@@ -178,14 +178,6 @@ export class BigQueryService {
 
         let filterDatasetByLocation = allDatasetList;
 
-        if (DEFAULT_PUBLIC_PROJECT_ID !== projectId) {
-            filterDatasetByLocation = filterDatasetByLocation.filter(
-            (dataset: any) =>
-              dataset.entrySource?.location?.toLowerCase() ===
-              String(settings.get('bqRegion')['composite']).toLowerCase()
-            );
-        }
-
         if (filterDatasetByLocation.length === 0) {
           setDataSetResponse([]);
           setDatabaseNames([]);

--- a/src/bigQuery/bigQueryService.tsx
+++ b/src/bigQuery/bigQueryService.tsx
@@ -147,11 +147,8 @@ export class BigQueryService {
     if (notebookValue) {
       const pageToken = nextPageToken ?? '';
       try {
-        const settings = await settingRegistry.load(PLUGIN_ID);
-        const location = settings.get('bqRegion')['composite']
-
         const data: any = await requestAPI(
-          `bigQueryDataset?project_id=${projectId}&location=${location}&pageToken=${pageToken}`
+          `bigQueryDataset?project_id=${projectId}&pageToken=${pageToken}`
         );
         if (!(data.entries || data.datasets)) {
           setDataSetResponse([]);


### PR DESCRIPTION
**Problem**
The Dataset Explorer hides zonal datasets (e.g., `us-central1`, `us-east4`) when the search field is empty. Only multi-zone datasets are shown. This is caused by using the regional Dataplex Entry Groups API and a strict frontend filter that excludes any dataset not matching the exact `bqRegion` setting, which usually correspond to a multi-region.

**Solution**
This PR switches the "empty search" listing to use the **Dataplex Search API**, matching the behavior already used for active searches.

*   **Backend:** Updated `list_datasets` to use the global `searchEntries` endpoint for private projects, ensuring all datasets are discovered regardless of zone.
*   **Frontend:** Removed the redundant location filter in `bigQueryService.tsx` to allow all identified datasets to be displayed.
*   **Compatibility:** Public dataset listing via the BigQuery API remains unchanged.

**Impact**
All project datasets are now visible in the explorer, regardless of their specific GCP region or zone.

**Testing**
Updated and verified backend tests (`test_bigquery.py`); all 11 cases pass.
Manual testing is currently in progress.