### PR TITLE
Fix subprocess execution on Windows event loops

### DIFF
--- a/dataproc_jupyter_plugin/commons/commands.py
+++ b/dataproc_jupyter_plugin/commons/commands.py
@@ -21,15 +21,19 @@ import tempfile
 
 async def async_run_gsutil_subcommand(cmd):
     """Run a specified command and return its output."""
-    with tempfile.TemporaryFile() as t:
-        p = await asyncio.create_subprocess_shell(
-            f"{cmd}",
+    def _run():
+        return subprocess.run(
+            cmd,
+            shell=True,
             stdin=subprocess.DEVNULL,
             stderr=sys.stderr,
-            stdout=t,
+            stdout=subprocess.PIPE,
+            text=True,
         )
-        await p.wait()
-        if p.returncode != 0:
-            raise subprocess.CalledProcessError(p.returncode, None, None, None)
-        t.seek(0)
-        return t.read().decode("UTF-8").strip()
+
+    loop = asyncio.get_running_loop()
+    p = await loop.run_in_executor(None, _run)
+
+    if p.returncode != 0:
+        raise subprocess.CalledProcessError(p.returncode, cmd, p.stdout, None)
+    return p.stdout.strip()

--- a/dataproc_jupyter_plugin/commons/commands.py
+++ b/dataproc_jupyter_plugin/commons/commands.py
@@ -19,14 +19,14 @@ import sys
 import tempfile
 
 
-async def async_run_gsutil_subcommand(cmd):
-    """Run a specified command and return its output."""
+async def async_run_command(cmd, stderr=subprocess.PIPE):
+    """Run a specified shell command in a thread executor and return the completed process."""
     def _run():
         return subprocess.run(
             cmd,
             shell=True,
             stdin=subprocess.DEVNULL,
-            stderr=sys.stderr,
+            stderr=stderr,
             stdout=subprocess.PIPE,
             text=True,
         )
@@ -35,5 +35,13 @@ async def async_run_gsutil_subcommand(cmd):
     p = await loop.run_in_executor(None, _run)
 
     if p.returncode != 0:
-        raise subprocess.CalledProcessError(p.returncode, cmd, p.stdout, None)
+        raise subprocess.CalledProcessError(
+            p.returncode, cmd, p.stdout, p.stderr
+        )
+    return p
+
+
+async def async_run_gsutil_subcommand(cmd):
+    """Run a specified command and return its output."""
+    p = await async_run_command(cmd, stderr=sys.stderr)
     return p.stdout.strip()

--- a/dataproc_jupyter_plugin/commons/commands.py
+++ b/dataproc_jupyter_plugin/commons/commands.py
@@ -43,5 +43,5 @@ async def async_run_command(cmd, stderr=subprocess.PIPE):
 
 async def async_run_gsutil_subcommand(cmd):
     """Run a specified command and return its output."""
-    p = await async_run_command(cmd, stderr=sys.stderr)
+    p = await async_run_command(cmd)
     return p.stdout.strip()

--- a/dataproc_jupyter_plugin/handlers.py
+++ b/dataproc_jupyter_plugin/handlers.py
@@ -213,23 +213,25 @@ class ResourceManagerHandler(APIHandler):
         try:
             project = await credentials._gcp_project()
             subcmd = f'projects describe {project} --format="value(projectNumber)"'
-            with tempfile.TemporaryFile() as t:
-                with tempfile.TemporaryFile() as errt:
-                    p = await asyncio.create_subprocess_shell(
-                        f"gcloud {subcmd}",
-                        stdin=subprocess.DEVNULL,
-                        stderr=errt,
-                        stdout=t,
-                    )
-                    await p.wait()
-                    if p.returncode != 0:
-                        errt.seek(0)
-                        stderr_str = errt.read().decode("UTF-8").strip()
-                        raise subprocess.CalledProcessError(
-                            p.returncode, f"gcloud {subcmd}", None, stderr_str
-                        )
-                    t.seek(0)
-                    t.read().decode("UTF-8").strip()
+            cmd = f"gcloud {subcmd}"
+
+            def _run():
+                return subprocess.run(
+                    cmd,
+                    shell=True,
+                    stdin=subprocess.DEVNULL,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    text=True,
+                )
+
+            loop = asyncio.get_running_loop()
+            p = await loop.run_in_executor(None, _run)
+
+            if p.returncode != 0:
+                raise subprocess.CalledProcessError(
+                    p.returncode, cmd, p.stdout, p.stderr
+                )
             self.finish({"status": "OK"})
         except subprocess.CalledProcessError as er:
             self.finish({"status": "ERROR", "error": er.stderr})

--- a/dataproc_jupyter_plugin/handlers.py
+++ b/dataproc_jupyter_plugin/handlers.py
@@ -34,6 +34,7 @@ from traitlets.config import SingletonConfigurable
 
 from dataproc_jupyter_plugin import credentials, urls
 from dataproc_jupyter_plugin.commons import constants
+from dataproc_jupyter_plugin.commons.commands import async_run_command
 from dataproc_jupyter_plugin.controllers import (
     bigquery,
     checkApiEnabled
@@ -215,23 +216,8 @@ class ResourceManagerHandler(APIHandler):
             subcmd = f'projects describe {project} --format="value(projectNumber)"'
             cmd = f"gcloud {subcmd}"
 
-            def _run():
-                return subprocess.run(
-                    cmd,
-                    shell=True,
-                    stdin=subprocess.DEVNULL,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE,
-                    text=True,
-                )
+            await async_run_command(cmd)
 
-            loop = asyncio.get_running_loop()
-            p = await loop.run_in_executor(None, _run)
-
-            if p.returncode != 0:
-                raise subprocess.CalledProcessError(
-                    p.returncode, cmd, p.stdout, p.stderr
-                )
             self.finish({"status": "OK"})
         except subprocess.CalledProcessError as er:
             self.finish({"status": "ERROR", "error": er.stderr})

--- a/dataproc_jupyter_plugin/tests/test_handlers.py
+++ b/dataproc_jupyter_plugin/tests/test_handlers.py
@@ -234,17 +234,15 @@ async def test_resource_manager_handler_success(jp_fetch, monkeypatch):
         "dataproc_jupyter_plugin.handlers.credentials._gcp_project", mock_gcp_project
     )
 
-    async def mock_create_subprocess_shell(*args, **kwargs):
-        class MockProcess:
+    def mock_subprocess_run(*args, **kwargs):
+        class MockResult:
             def __init__(self):
                 self.returncode = 0
+                self.stdout = "OK"
+                self.stderr = ""
+        return MockResult()
 
-            async def wait(self):
-                pass
-
-        return MockProcess()
-
-    monkeypatch.setattr("asyncio.create_subprocess_shell", mock_create_subprocess_shell)
+    monkeypatch.setattr("subprocess.run", mock_subprocess_run)
 
     # Call the handler
     response = await jp_fetch(
@@ -267,38 +265,15 @@ async def test_resource_manager_handler_error(jp_fetch, monkeypatch):
         "dataproc_jupyter_plugin.handlers.credentials._gcp_project", mock_gcp_project
     )
 
-    # Mock the subprocess for gcloud command execution to simulate an error
-    async def mock_create_subprocess_shell(*args, **kwargs):
-        class MockProcess:
+    def mock_subprocess_run(*args, **kwargs):
+        class MockResult:
             def __init__(self):
                 self.returncode = 1
+                self.stdout = ""
+                self.stderr = "Simulated gcloud error"
+        return MockResult()
 
-            async def wait(self):
-                pass
-
-        return MockProcess()
-
-    monkeypatch.setattr("asyncio.create_subprocess_shell", mock_create_subprocess_shell)
-
-    # Mock the error output from the subprocess
-    def mock_tempfile():
-        class MockTempFile:
-            def __enter__(self):
-                self.content = b"Simulated gcloud error"
-                return self
-
-            def __exit__(self, exc_type, exc_val, exc_tb):
-                pass
-
-            def seek(self, pos):
-                pass
-
-            def read(self):
-                return self.content
-
-        return MockTempFile()
-
-    monkeypatch.setattr("tempfile.TemporaryFile", mock_tempfile)
+    monkeypatch.setattr("subprocess.run", mock_subprocess_run)
 
     # Call the handler
     response = await jp_fetch(


### PR DESCRIPTION
> This PR solves b/497845035.

## Description
This PR fixes a `NotImplementedError` that is raised when the Dataproc Jupyter plugin attempts to execute a shell subprocess on a Windows VM.

### The Issue
Tornado's default event loop implementation on Windows relies on the `SelectorEventLoop`, which does not support `asyncio.create_subprocess_shell()`. As a result, operations that invoke `gcloud` or `gsutil` subprocesses, such as `ResourceManagerHandler.post` or `async_run_gsutil_subcommand`, would crash immediately on a Windows machine.

### The Solution
To maintain compatibility across all platforms (including Windows) while preserving the non-blocking nature of the Jupyter server, this PR replaces the usage of `asyncio.create_subprocess_shell` with standard `subprocess.run` calls wrapped inside the event loop's thread executor (`loop.run_in_executor`). 

### Changes
*   **`dataproc_jupyter_plugin/commons/commands.py`**: Refactored `async_run_gsutil_subcommand` to use `subprocess.run` inside `loop.run_in_executor`.
*   **`dataproc_jupyter_plugin/handlers.py`**: Refactored the `gcloud projects describe` command in `ResourceManagerHandler.post` to execute the same way.
*   **`dataproc_jupyter_plugin/tests/test_handlers.py`**: Updated unit tests to mock `subprocess.run` instead of `asyncio.create_subprocess_shell` and ensured all tests continue to pass.