### PR TITLE
Use shared library to invoke gcloud

### DIFF
--- a/dataproc_jupyter_plugin/handlers.py
+++ b/dataproc_jupyter_plugin/handlers.py
@@ -12,12 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import asyncio
 import json
 import re
 import subprocess
-import sys
-import tempfile
 
 
 from google.cloud.jupyter_config.config import (
@@ -212,27 +209,12 @@ class ResourceManagerHandler(APIHandler):
     async def post(self):
         try:
             project = await credentials._gcp_project()
-            subcmd = f'projects describe {project} --format="value(projectNumber)"'
-            with tempfile.TemporaryFile() as t:
-                with tempfile.TemporaryFile() as errt:
-                    p = await asyncio.create_subprocess_shell(
-                        f"gcloud {subcmd}",
-                        stdin=subprocess.DEVNULL,
-                        stderr=errt,
-                        stdout=t,
-                    )
-                    await p.wait()
-                    if p.returncode != 0:
-                        errt.seek(0)
-                        stderr_str = errt.read().decode("UTF-8").strip()
-                        raise subprocess.CalledProcessError(
-                            p.returncode, f"gcloud {subcmd}", None, stderr_str
-                        )
-                    t.seek(0)
-                    t.read().decode("UTF-8").strip()
+            await async_run_gcloud_subcommand(
+                f'projects describe {project} --format="value(projectNumber)"'
+            )
             self.finish({"status": "OK"})
         except subprocess.CalledProcessError as er:
-            self.finish({"status": "ERROR", "error": er.stderr})
+            self.finish({"status": "ERROR", "error": str(er)})
 
 
 def setup_handlers(web_app):

--- a/dataproc_jupyter_plugin/handlers.py
+++ b/dataproc_jupyter_plugin/handlers.py
@@ -214,7 +214,7 @@ class ResourceManagerHandler(APIHandler):
             )
             self.finish({"status": "OK"})
         except subprocess.CalledProcessError as er:
-            self.finish({"status": "ERROR", "error": str(er)})
+            self.finish({"status": "ERROR", "error": er.stderr})
 
 
 def setup_handlers(web_app):

--- a/dataproc_jupyter_plugin/tests/test_handlers.py
+++ b/dataproc_jupyter_plugin/tests/test_handlers.py
@@ -268,7 +268,9 @@ async def test_resource_manager_handler_error(jp_fetch, monkeypatch):
 
     # Mock a failure in the gcloud command execution
     mock_run_gcloud = AsyncMock(
-        side_effect=subprocess.CalledProcessError(1, "gcloud projects describe")
+        side_effect=subprocess.CalledProcessError(
+            1, "gcloud projects describe", stderr="Simulated gcloud error"
+        )
     )
     monkeypatch.setattr(
         "dataproc_jupyter_plugin.handlers.async_run_gcloud_subcommand", mock_run_gcloud
@@ -286,3 +288,4 @@ async def test_resource_manager_handler_error(jp_fetch, monkeypatch):
     assert response.code == 200
     payload = json.loads(response.body)
     assert payload["status"] == "ERROR"
+    assert payload["error"] == "Simulated gcloud error"

--- a/dataproc_jupyter_plugin/tests/test_handlers.py
+++ b/dataproc_jupyter_plugin/tests/test_handlers.py
@@ -234,17 +234,11 @@ async def test_resource_manager_handler_success(jp_fetch, monkeypatch):
         "dataproc_jupyter_plugin.handlers.credentials._gcp_project", mock_gcp_project
     )
 
-    async def mock_create_subprocess_shell(*args, **kwargs):
-        class MockProcess:
-            def __init__(self):
-                self.returncode = 0
-
-            async def wait(self):
-                pass
-
-        return MockProcess()
-
-    monkeypatch.setattr("asyncio.create_subprocess_shell", mock_create_subprocess_shell)
+    # Mock the gcloud command execution
+    mock_run_gcloud = AsyncMock(return_value="123456789")
+    monkeypatch.setattr(
+        "dataproc_jupyter_plugin.handlers.async_run_gcloud_subcommand", mock_run_gcloud
+    )
 
     # Call the handler
     response = await jp_fetch(
@@ -259,6 +253,11 @@ async def test_resource_manager_handler_success(jp_fetch, monkeypatch):
     payload = json.loads(response.body)
     assert payload["status"] == "OK"
 
+    # Verify the correct gcloud command was called
+    mock_run_gcloud.assert_called_once_with(
+        'projects describe my-project-123 --format="value(projectNumber)"'
+    )
+
 
 async def test_resource_manager_handler_error(jp_fetch, monkeypatch):
     # Mock the project ID retrieval
@@ -267,38 +266,13 @@ async def test_resource_manager_handler_error(jp_fetch, monkeypatch):
         "dataproc_jupyter_plugin.handlers.credentials._gcp_project", mock_gcp_project
     )
 
-    # Mock the subprocess for gcloud command execution to simulate an error
-    async def mock_create_subprocess_shell(*args, **kwargs):
-        class MockProcess:
-            def __init__(self):
-                self.returncode = 1
-
-            async def wait(self):
-                pass
-
-        return MockProcess()
-
-    monkeypatch.setattr("asyncio.create_subprocess_shell", mock_create_subprocess_shell)
-
-    # Mock the error output from the subprocess
-    def mock_tempfile():
-        class MockTempFile:
-            def __enter__(self):
-                self.content = b"Simulated gcloud error"
-                return self
-
-            def __exit__(self, exc_type, exc_val, exc_tb):
-                pass
-
-            def seek(self, pos):
-                pass
-
-            def read(self):
-                return self.content
-
-        return MockTempFile()
-
-    monkeypatch.setattr("tempfile.TemporaryFile", mock_tempfile)
+    # Mock a failure in the gcloud command execution
+    mock_run_gcloud = AsyncMock(
+        side_effect=subprocess.CalledProcessError(1, "gcloud projects describe")
+    )
+    monkeypatch.setattr(
+        "dataproc_jupyter_plugin.handlers.async_run_gcloud_subcommand", mock_run_gcloud
+    )
 
     # Call the handler
     response = await jp_fetch(
@@ -312,4 +286,3 @@ async def test_resource_manager_handler_error(jp_fetch, monkeypatch):
     assert response.code == 200
     payload = json.loads(response.body)
     assert payload["status"] == "ERROR"
-    assert payload["error"] == "Simulated gcloud error"

--- a/src/index.ts
+++ b/src/index.ts
@@ -399,7 +399,7 @@ const extension: JupyterFrontEndPlugin<void> = {
                 autoClose: false
               });
             } else {
-              Notification.error(`Error in running gcloud command: ${error}`, {
+              Notification.error(`'Error resourceManager API': ${error}`, {
                 autoClose: false
               });
             }

--- a/src/index.ts
+++ b/src/index.ts
@@ -399,7 +399,7 @@ const extension: JupyterFrontEndPlugin<void> = {
                 autoClose: false
               });
             } else {
-              Notification.error(`Error resourceManager API: ${error}`, {
+              Notification.error(`Error calling into the Resource Manager API: ${error}`, {
                 autoClose: false
               });
             }

--- a/src/index.ts
+++ b/src/index.ts
@@ -399,7 +399,7 @@ const extension: JupyterFrontEndPlugin<void> = {
                 autoClose: false
               });
             } else {
-              Notification.error(`'Error resourceManager API': ${error}`, {
+              Notification.error(`Error resourceManager API: ${error}`, {
                 autoClose: false
               });
             }


### PR DESCRIPTION
This PR reverts:

https://github.com/GoogleCloudDataproc/dataproc-jupyter-plugin/commit/a3f7a1488d913012d01f577513451add7644868b

To use a native way to invoke gcloud commands.