### PR TITLE
Add MIN_GATEWAY_CONNECT_TIMEOUT constant

### DIFF
--- a/dataproc_jupyter_plugin/__init__.py
+++ b/dataproc_jupyter_plugin/__init__.py
@@ -22,7 +22,7 @@ from kernels_mixer.websockets import DelegatingWebsocketConnection
 from .handlers import DataprocPluginConfig, configure_gateway_client_url, setup_handlers
 
 # In seconds
-MIN_GATEWAY_REQUEST_TIMEOUT = 600
+MIN_GATEWAY_REQUEST_TIMEOUT = 300
 
 # In seconds
 MIN_GATEWAY_CONNECT_TIMEOUT = 300

--- a/dataproc_jupyter_plugin/__init__.py
+++ b/dataproc_jupyter_plugin/__init__.py
@@ -25,6 +25,9 @@ from .handlers import DataprocPluginConfig, configure_gateway_client_url, setup_
 MIN_GATEWAY_REQUEST_TIMEOUT = 600
 
 # In seconds
+MIN_GATEWAY_CONNECT_TIMEOUT = 300
+
+# In seconds
 MIN_GATEWAY_RETRY_INTERVAL = 20
 
 # In number of iterations
@@ -95,11 +98,15 @@ def _link_jupyter_server_extension(server_app):
         c.GatewayClient.gateway_retry_max, MIN_GATEWAY_RETRY_MAX
     )
 
+
     # The default gateway client request timeout is 42 seconds but the POST request to
-    # create a batch can take upwards to 600 seconds, so we want to increase the timeout
-    # so that the minimum is 600 seconds.
+    # create a batch can take upwards to 300 seconds, so we want to set the timeout
+    # based on the long tail latency of Component Gateway requests
     c.GatewayClient.request_timeout = _get_config_value_to_assign(
         c.GatewayClient.request_timeout, MIN_GATEWAY_REQUEST_TIMEOUT
+    )
+    c.GatewayClient.connect_timeout = _get_config_value_to_assign(
+        c.GatewayClient.connect_timeout, MIN_GATEWAY_CONNECT_TIMEOUT
     )
 
     # Version 2.8.0 of the `jupyter_server` package requires the `auth_token`

--- a/dataproc_jupyter_plugin/__init__.py
+++ b/dataproc_jupyter_plugin/__init__.py
@@ -22,7 +22,7 @@ from kernels_mixer.websockets import DelegatingWebsocketConnection
 from .handlers import DataprocPluginConfig, configure_gateway_client_url, setup_handlers
 
 # In seconds
-MIN_GATEWAY_REQUEST_TIMEOUT = 300
+MIN_GATEWAY_REQUEST_TIMEOUT = 600
 
 # In seconds
 MIN_GATEWAY_CONNECT_TIMEOUT = 300
@@ -100,8 +100,8 @@ def _link_jupyter_server_extension(server_app):
 
 
     # The default gateway client request timeout is 42 seconds but the POST request to
-    # create a batch can take upwards to 300 seconds, so we want to set the timeout
-    # based on the long tail latency of Component Gateway requests
+    # create a batch can take upwards to 600 seconds, so we want to increase the timeout
+    # so that the minimum is 600 seconds.
     c.GatewayClient.request_timeout = _get_config_value_to_assign(
         c.GatewayClient.request_timeout, MIN_GATEWAY_REQUEST_TIMEOUT
     )

--- a/dataproc_jupyter_plugin/tests/test_handlers.py
+++ b/dataproc_jupyter_plugin/tests/test_handlers.py
@@ -48,7 +48,8 @@ async def test_get_default_config(jp_serverapp):
     assert server_config.DataprocPluginConfig.kernel_gateway_project_number == ""
     assert server_config.GatewayClient.gateway_retry_interval == 20
     assert server_config.GatewayClient.gateway_retry_max == 45
-    assert server_config.GatewayClient.request_timeout == 600
+    assert server_config.GatewayClient.request_timeout == 300
+    assert server_config.GatewayClient.connect_timeout == 300
 
 @pytest.mark.parametrize(
     "config_project_number,expected_calls",

--- a/dataproc_jupyter_plugin/tests/test_handlers.py
+++ b/dataproc_jupyter_plugin/tests/test_handlers.py
@@ -48,7 +48,7 @@ async def test_get_default_config(jp_serverapp):
     assert server_config.DataprocPluginConfig.kernel_gateway_project_number == ""
     assert server_config.GatewayClient.gateway_retry_interval == 20
     assert server_config.GatewayClient.gateway_retry_max == 45
-    assert server_config.GatewayClient.request_timeout == 300
+    assert server_config.GatewayClient.request_timeout == 600
     assert server_config.GatewayClient.connect_timeout == 300
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Lowered the previous request timeout from 600s to 300s, since based on the empirical data the previous was an overkill. Added a new constant for minimum gateway connect timeout of 300s as well.