### PR TITLE
feat: add configurable user-agent traitlet for gateway client

### DIFF
--- a/dataproc_jupyter_plugin/__init__.py
+++ b/dataproc_jupyter_plugin/__init__.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.from ._version import __version__
 import logging
-import json
 
 from google.cloud.jupyter_config.tokenrenewer import CommandTokenRenewer
 from jupyter_server.services.sessions.sessionmanager import SessionManager

--- a/dataproc_jupyter_plugin/__init__.py
+++ b/dataproc_jupyter_plugin/__init__.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.from ._version import __version__
 import logging
+import json
 
 from google.cloud.jupyter_config.tokenrenewer import CommandTokenRenewer
 from jupyter_server.services.sessions.sessionmanager import SessionManager
@@ -81,7 +82,13 @@ def _link_jupyter_server_extension(server_app):
     c.DelegatingWebsocketConnection.kernel_ws_protocol = ""
 
     c.GatewayClient.auth_scheme = "Bearer"
-    c.GatewayClient.headers = '{"Cookie": "_xsrf=XSRF", "X-XSRFToken": "XSRF"}'
+    headers = {
+        "Cookie": "_xsrf=XSRF",
+        "X-XSRFToken": "XSRF"
+    }
+    if plugin_config.custom_user_agent:
+        headers["User-Agent"] = plugin_config.custom_user_agent
+    c.GatewayClient.headers = json.dumps(headers)
     c.GatewayClient.gateway_token_renewer_class = CommandTokenRenewer
     c.CommandTokenRenewer.token_command = (
         'gcloud config config-helper --format="value(credential.access_token)"'

--- a/dataproc_jupyter_plugin/__init__.py
+++ b/dataproc_jupyter_plugin/__init__.py
@@ -10,12 +10,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-from importlib.metadata import version, PackageNotFoundError
-
-try:
-    __version__ = version("dataproc_jupyter_plugin")
-except PackageNotFoundError:
-    __version__ = "unknown"
+# limitations under the License.
 
 import logging
 import json

--- a/dataproc_jupyter_plugin/__init__.py
+++ b/dataproc_jupyter_plugin/__init__.py
@@ -88,7 +88,7 @@ def _link_jupyter_server_extension(server_app):
     }
     if plugin_config.custom_user_agent:
         headers["User-Agent"] = plugin_config.custom_user_agent
-    c.GatewayClient.headers = json.dumps(headers)
+    c.GatewayClient.headers = headers
     c.GatewayClient.gateway_token_renewer_class = CommandTokenRenewer
     c.CommandTokenRenewer.token_command = (
         'gcloud config config-helper --format="value(credential.access_token)"'

--- a/dataproc_jupyter_plugin/__init__.py
+++ b/dataproc_jupyter_plugin/__init__.py
@@ -10,7 +10,13 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License.from ._version import __version__
+from importlib.metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version("dataproc_jupyter_plugin")
+except PackageNotFoundError:
+    __version__ = "unknown"
+
 import logging
 import json
 

--- a/dataproc_jupyter_plugin/__init__.py
+++ b/dataproc_jupyter_plugin/__init__.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.from ._version import __version__
 import logging
+import json
 
 from google.cloud.jupyter_config.tokenrenewer import CommandTokenRenewer
 from jupyter_server.services.sessions.sessionmanager import SessionManager
@@ -87,7 +88,7 @@ def _link_jupyter_server_extension(server_app):
     }
     if plugin_config.custom_user_agent:
         headers["User-Agent"] = plugin_config.custom_user_agent
-    c.GatewayClient.headers = headers
+    c.GatewayClient.headers = json.dumps(headers)
     c.GatewayClient.gateway_token_renewer_class = CommandTokenRenewer
     c.CommandTokenRenewer.token_command = (
         'gcloud config config-helper --format="value(credential.access_token)"'

--- a/dataproc_jupyter_plugin/handlers.py
+++ b/dataproc_jupyter_plugin/handlers.py
@@ -111,7 +111,6 @@ class DataprocPluginConfig(SingletonConfigurable):
     )
 
 
-
 class SettingsHandler(APIHandler):
     @tornado.web.authenticated
     def get(self):

--- a/dataproc_jupyter_plugin/handlers.py
+++ b/dataproc_jupyter_plugin/handlers.py
@@ -104,6 +104,13 @@ class DataprocPluginConfig(SingletonConfigurable):
         help="Use this project number for kernel gateway and skip project number verification",
     )
 
+    custom_user_agent = Unicode(
+        "dataproc-jupyter-plugin",
+        config=True,
+        help="Custom User-Agent header value for outbound requests to the kernels mixer.",
+    )
+
+
 
 class SettingsHandler(APIHandler):
     @tornado.web.authenticated

--- a/dataproc_jupyter_plugin/handlers.py
+++ b/dataproc_jupyter_plugin/handlers.py
@@ -41,6 +41,13 @@ from dataproc_jupyter_plugin.controllers.version import (
     tornado
 )
 
+from importlib.metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version("dataproc_jupyter_plugin")
+except PackageNotFoundError:
+    __version__ = "unknown"
+
 _region_not_set_error = """GCP region not set in gcloud.
 
 You must configure either the `compute/region` or `dataproc/region` setting
@@ -105,7 +112,7 @@ class DataprocPluginConfig(SingletonConfigurable):
     )
 
     custom_user_agent = Unicode(
-        "dataproc-jupyter-plugin",
+        f"dataproc-jupyter-plugin/{__version__}",
         config=True,
         help="Custom User-Agent header value for outbound requests to the kernels mixer.",
     )

--- a/dataproc_jupyter_plugin/tests/test_handlers.py
+++ b/dataproc_jupyter_plugin/tests/test_handlers.py
@@ -113,8 +113,18 @@ async def test_post_config_handler_success(jp_fetch, monkeypatch, jp_serverapp, 
 )
 async def test_valid_project_ids(jp_fetch, monkeypatch, project_id):
     mock_run_gcloud = AsyncMock()
+    mock_clear_cache = Mock()
+    mock_configure_gateway = Mock(return_value=True)
+
     monkeypatch.setattr(
         "dataproc_jupyter_plugin.handlers.async_run_gcloud_subcommand", mock_run_gcloud
+    )
+    monkeypatch.setattr(
+        "dataproc_jupyter_plugin.handlers.clear_gcloud_cache", mock_clear_cache
+    )
+    monkeypatch.setattr(
+        "dataproc_jupyter_plugin.handlers.configure_gateway_client_url",
+        mock_configure_gateway,
     )
 
     body = {"projectId": project_id, "region": "us-central1"}
@@ -166,8 +176,18 @@ async def test_invalid_project_ids(jp_fetch, monkeypatch, invalid_project_id):
 )
 async def test_valid_regions(jp_fetch, monkeypatch, region):
     mock_run_gcloud = AsyncMock()
+    mock_clear_cache = Mock()
+    mock_configure_gateway = Mock(return_value=True)
+
     monkeypatch.setattr(
         "dataproc_jupyter_plugin.handlers.async_run_gcloud_subcommand", mock_run_gcloud
+    )
+    monkeypatch.setattr(
+        "dataproc_jupyter_plugin.handlers.clear_gcloud_cache", mock_clear_cache
+    )
+    monkeypatch.setattr(
+        "dataproc_jupyter_plugin.handlers.configure_gateway_client_url",
+        mock_configure_gateway,
     )
 
     body = {"projectId": "valid-project-123", "region": region}


### PR DESCRIPTION
### Overview
This PR surfaces the client type dimension into our logs for downstream analysis

### Changes Made
1. **Added a Traitlet:** Defined a new configurable `custom_user_agent` traitlet inside `DataprocPluginConfig` with a default value of `dataproc-jupyter-plugin` (allowing advanced users to override it if needed).
2. **Injected Header:** Updated the server extension initialization to dynamically read this traitlet and inject it as the `User-Agent` header into `GatewayClient.headers` for all outbound requests.