### PR TITLE
fix: Fix Lightning Engine property update failure in runtime creation

### DIFF
--- a/src/jobs/labelProperties.tsx
+++ b/src/jobs/labelProperties.tsx
@@ -75,7 +75,7 @@ function LabelProperties({
         setLabelDetail([DEFAULT_LABEL_DETAIL]);
         setLabelDetailUpdated([DEFAULT_LABEL_DETAIL]);
       } else {
-        if (!selectedRuntimeClone) {
+        if (!selectedRuntimeClone && labelDetail.length === 0) {
           setLabelDetailUpdated([]);
           setLabelDetail([]);
         }
@@ -197,7 +197,7 @@ function LabelProperties({
                   */
             const labelSplit = label.split(':');
             return (
-              <div key={label}>
+              <div key={index}>
                 <div className="job-label-edit-row">
                   <div className="key-message-wrapper">
                     <div className="select-text-overlay-label">
@@ -223,7 +223,7 @@ function LabelProperties({
                         onChange={e =>
                           handleEditLabel(e.target.value, index, 'key')
                         }
-                        defaultValue={labelSplit[0]}
+                        value={labelSplit[0]}
                         Label={`Key ${index + 1}*`}
                       />
                     </div>
@@ -287,7 +287,7 @@ function LabelProperties({
                           buttonText === 'ADD LABEL') || label.startsWith(DATAPROC_TIER_PROPERTY)
                           || label.startsWith(DATAPROC_LIGHTNING_ENGINE_PROPERTY)
                         }
-                        defaultValue={
+                        value={
                           labelSplit.length > 2
                             ? label.split(/:(.+)/)[1]
                             : labelSplit[1]

--- a/src/runtime/createRunTime.tsx
+++ b/src/runtime/createRunTime.tsx
@@ -232,6 +232,10 @@ function CreateRunTime({
   const catalogNameRegEx = /^[a-zA-Z0-9_]*$/;
   const [isValidCatalogName, setIsValidCatalogName] = useState(true);
 
+  const areStringArraysEqual = (left: string[], right: string[]) =>
+    left.length === right.length &&
+    left.every((item, index) => item === right[index]);
+
   useEffect(() => {
     if (metastoreType === 'biglake') {
       const catalogPrefix = `spark.sql.catalog.${catalogName}`;
@@ -337,15 +341,13 @@ function CreateRunTime({
   // This solves a race condition seen in certain environments where setting both states
   // in the same function call would fail.
   useEffect(() => {
-   if (JSON.stringify(labelDetail) !== JSON.stringify(labelDetailUpdated)) {
+    if (!areStringArraysEqual(labelDetail, labelDetailUpdated)) {
       setLabelDetail(labelDetailUpdated);
     }
   }, [labelDetailUpdated, labelDetail]);
 
   useEffect(() => {
-    if (
-      JSON.stringify(propertyDetail) !== JSON.stringify(propertyDetailUpdated)
-    ) {
+    if (!areStringArraysEqual(propertyDetail, propertyDetailUpdated)) {
       setPropertyDetail(propertyDetailUpdated);
     }
   }, [propertyDetailUpdated, propertyDetail]);

--- a/src/runtime/createRunTime.tsx
+++ b/src/runtime/createRunTime.tsx
@@ -266,7 +266,6 @@ function CreateRunTime({
   const [apiDialogOpen, setApiDialogOpen] = useState(false);
   const [lightningEngineEnabled, setLightningEngineEnabled] = useState(false);
   const [enableLink, setEnableLink] = useState('');
-  const [othersList , setOthersList] = useState<string[]>([]);
   const runtimeOptions = [
     {
       value: '2.3',
@@ -286,19 +285,19 @@ function CreateRunTime({
     }
   ];
 
-  const updateLightningEngineProperty = (currentOthersList = othersList) => {
-    const lightningProperty = DATAPROC_LIGHTNING_ENGINE_PROPERTY + ":" + (lightningEngineEnabled
-    ? 'lightningEngine'
-    : 'default');
-  
-    const updatedProperties = [lightningProperty, ...currentOthersList];
-    setPropertyDetailUpdated(updatedProperties);
-    return updatedProperties;
-  }
-
   useEffect(() => {
-    updateLightningEngineProperty();
-  }, [lightningEngineEnabled,othersList]);
+    setPropertyDetailUpdated(prev => {
+      const lightningProperty = DATAPROC_LIGHTNING_ENGINE_PROPERTY + ":" + (lightningEngineEnabled ? 'lightningEngine' : 'default');
+      const newList = [...prev];
+      const index = newList.findIndex(prop => prop.startsWith(DATAPROC_LIGHTNING_ENGINE_PROPERTY + ':'));
+      if (index !== -1) {
+        newList[index] = lightningProperty;
+      } else {
+        newList.unshift(lightningProperty);
+      }
+      return newList;
+    });
+  }, [lightningEngineEnabled]);
 
   useEffect(() => {
     const initializeRuntime = async () => {
@@ -318,7 +317,6 @@ function CreateRunTime({
           listNetworksAPI();
           listKeyRingsAPI();
           runtimeSharedProject();
-          updateLightningEngineProperty(othersList);
         } else {
           setConfigLoading(false);
         }
@@ -656,6 +654,8 @@ function CreateRunTime({
             let gpuDetailList: string[] = [];
             let metaStoreDetailList: string[] = [];
             let otherDetailList: string[] = [];
+            let hasLightning = false;
+            let lightningValue = 'default';
             updatedPropertyDetail.forEach(property => {
               if (
                 RESOURCE_ALLOCATION_DEFAULT.some(item => {
@@ -681,8 +681,9 @@ function CreateRunTime({
               } else if (property.startsWith('spark.sql.catalog.')) {
                 metaStoreDetailList.push(property);
               } else if (property.startsWith(DATAPROC_LIGHTNING_ENGINE_PROPERTY)) {
-                const value = property.split(':')[1];
-                setLightningEngineEnabled(value === 'lightningEngine');
+                lightningValue = property.split(':')[1];
+                setLightningEngineEnabled(lightningValue === 'lightningEngine');
+                hasLightning = true;
               }  else {
                 otherDetailList.push(property);
               }
@@ -693,7 +694,11 @@ function CreateRunTime({
             setAutoScalingDetailUpdated(autoScalingDetailList);
             setMetastoreDetail(metaStoreDetailList);
             setMetastoreDetailUpdated(metaStoreDetailList);
-            setOthersList(otherDetailList);
+            
+            const lightningPropStr = DATAPROC_LIGHTNING_ENGINE_PROPERTY + ":" + (hasLightning ? lightningValue : 'default');
+            otherDetailList.unshift(lightningPropStr);
+            setPropertyDetail(otherDetailList);
+            setPropertyDetailUpdated(otherDetailList);
             if (metaStoreDetailList.length > 0) {
               setMetastoreType('biglake');
               const warehouseProperty = metaStoreDetailList.find(prop =>

--- a/src/runtime/createRunTime.tsx
+++ b/src/runtime/createRunTime.tsx
@@ -337,13 +337,15 @@ function CreateRunTime({
   // This solves a race condition seen in certain environments where setting both states
   // in the same function call would fail.
   useEffect(() => {
-    if (labelDetail.length !== labelDetailUpdated.length) {
+   if (JSON.stringify(labelDetail) !== JSON.stringify(labelDetailUpdated)) {
       setLabelDetail(labelDetailUpdated);
     }
   }, [labelDetailUpdated, labelDetail]);
 
   useEffect(() => {
-    if (propertyDetail.length !== propertyDetailUpdated.length) {
+    if (
+      JSON.stringify(propertyDetail) !== JSON.stringify(propertyDetailUpdated)
+    ) {
       setPropertyDetail(propertyDetailUpdated);
     }
   }, [propertyDetailUpdated, propertyDetail]);

--- a/src/runtime/createRunTime.tsx
+++ b/src/runtime/createRunTime.tsx
@@ -232,10 +232,6 @@ function CreateRunTime({
   const catalogNameRegEx = /^[a-zA-Z0-9_]*$/;
   const [isValidCatalogName, setIsValidCatalogName] = useState(true);
 
-  const areStringArraysEqual = (left: string[], right: string[]) =>
-    left.length === right.length &&
-    left.every((item, index) => item === right[index]);
-
   useEffect(() => {
     if (metastoreType === 'biglake') {
       const catalogPrefix = `spark.sql.catalog.${catalogName}`;
@@ -341,13 +337,15 @@ function CreateRunTime({
   // This solves a race condition seen in certain environments where setting both states
   // in the same function call would fail.
   useEffect(() => {
-    if (!areStringArraysEqual(labelDetail, labelDetailUpdated)) {
+   if (JSON.stringify(labelDetail) !== JSON.stringify(labelDetailUpdated)) {
       setLabelDetail(labelDetailUpdated);
     }
   }, [labelDetailUpdated, labelDetail]);
 
   useEffect(() => {
-    if (!areStringArraysEqual(propertyDetail, propertyDetailUpdated)) {
+    if (
+      JSON.stringify(propertyDetail) !== JSON.stringify(propertyDetailUpdated)
+    ) {
       setPropertyDetail(propertyDetailUpdated);
     }
   }, [propertyDetailUpdated, propertyDetail]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4157,14 +4157,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@playwright/test@npm:^1.32.0, @playwright/test@npm:^1.43.1":
-  version: 1.48.1
-  resolution: "@playwright/test@npm:1.48.1"
+"@playwright/test@npm:^1.60.0":
+  version: 1.61.1
+  resolution: "@playwright/test@npm:1.61.1"
   dependencies:
-    playwright: 1.48.1
+    playwright: 1.61.1
   bin:
     playwright: cli.js
-  checksum: 3f3f32dadeea9da4b9f835ba41d6bfabbd4c8d322bbba059250cb7bbdf2ae8fd32d547f64cef0bda492dff32128b4d4d802422525995570ebb57e62605c0557f
+  checksum: cf664aa3f5ccc63061ec8a96cf957ad2160b0a300035b310b9fcf67da43f52681fb775755c6134230e0ace7b391a08d9cfe7ca9664546d1bb5d4cf02e1db170a
   languageName: node
   linkType: hard
 
@@ -9327,7 +9327,7 @@ __metadata:
   resolution: "dataproc_jupyter_plugin-ui-tests@workspace:ui-tests"
   dependencies:
     "@jupyterlab/galata": ^5.0.0
-    "@playwright/test": ^1.32.0
+    "@playwright/test": ^1.60.0
   languageName: unknown
   linkType: soft
 
@@ -14883,27 +14883,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"playwright-core@npm:1.48.1":
-  version: 1.48.1
-  resolution: "playwright-core@npm:1.48.1"
+"playwright-core@npm:1.61.1":
+  version: 1.61.1
+  resolution: "playwright-core@npm:1.61.1"
   bin:
     playwright-core: cli.js
-  checksum: adf5b43e054e49bcc712d70e71dedab92c362ea76a45a767bdf3d928d3c810a42f6f1c49382f3d44ed005986048001f75cb568605031215dc89a3e56d99d2976
+  checksum: 69bd5c4eb1884a16e92674c0399ad25120ce91faecadd25227cb07eaa0892cce07f908c6bad51256363bf17634953759c30d42d7c253128c28bc8b86087a1f62
   languageName: node
   linkType: hard
 
-"playwright@npm:1.48.1":
-  version: 1.48.1
-  resolution: "playwright@npm:1.48.1"
+"playwright@npm:1.61.1":
+  version: 1.61.1
+  resolution: "playwright@npm:1.61.1"
   dependencies:
     fsevents: 2.3.2
-    playwright-core: 1.48.1
+    playwright-core: 1.61.1
   dependenciesMeta:
     fsevents:
       optional: true
   bin:
     playwright: cli.js
-  checksum: 81ca13392ad5e5ca87a226d0f5ff2da958c4e06a01dd6b56b4e4e5b4fec45ef8a8f7f0563ef0f4c725814265b931984d0c841e8524362b24480bcd527aa0c054
+  checksum: 2d85be1b6a88dbeeb206c5800629182840f07bd0e5e74f154fa57de2f1df16631918df9139a1cb8ddde8f2f125c5c9e447686a0fdadb61552b668ba97ffcaaf1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes an issue where toggling the "Enable Lightning Engine" checkbox fails to update the spark.dataproc.engine property