### PR TITLE
fix: Fix Lightning Engine property update failure in runtime creation

### DIFF
--- a/src/batches/batchDetails.tsx
+++ b/src/batches/batchDetails.tsx
@@ -147,7 +147,7 @@ function BatchDetails({
   });
   const [regionName, setRegionName] = useState('');
   const [errorView, setErrorView] = useState(false);
-  const [labelDetail, setLabelDetail] = useState(['']);
+  const [labelDetail, setLabelDetail] = useState<string[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [deletePopupOpen, setDeletePopupOpen] = useState(false);
   const [selectedBatch, setSelectedBatch] = useState('');

--- a/src/batches/createBatch.tsx
+++ b/src/batches/createBatch.tsx
@@ -226,10 +226,10 @@ function CreateBatch({
   const [networkTagSelected, setNetworkTagSelected] = useState([
     ...networkUris
   ]);
-  const [propertyDetail, setPropertyDetail] = useState(['']);
+  const [propertyDetail, setPropertyDetail] = useState<string[]>([]);
   const [selectedEncryptionRadio, setSelectedEncryptionRadio] =
     useState(selectedKeyType);
-  const [propertyDetailUpdated, setPropertyDetailUpdated] = useState(['']);
+  const [propertyDetailUpdated, setPropertyDetailUpdated] = useState<string[]>([]);
   const [keyValidation, setKeyValidation] = useState(-1);
   const [valueValidation, setValueValidation] = useState(-1);
   const [duplicateKeyError, setDuplicateKeyError] = useState(-1);
@@ -247,8 +247,8 @@ function CreateBatch({
   const [subNetworkSelected, setSubNetworkSelected] = useState(subNetwork);
   const [isLoadingService, setIsLoadingService] = useState(false);
   const [error, setError] = useState({ isOpen: false, message: '' });
-  const [parameterDetail, setParameterDetail] = useState(['']);
-  const [parameterDetailUpdated, setParameterDetailUpdated] = useState(['']);
+  const [parameterDetail, setParameterDetail] = useState<string[]>([]);
+  const [parameterDetailUpdated, setParameterDetailUpdated] = useState<string[]>([]);
   const [additionalPythonFileSelected, setAdditionalPythonFileSelected] =
     useState([...pythonFileUris]);
   const [mainPythonSelected, setMainPythonSelected] =

--- a/src/jobs/labelProperties.tsx
+++ b/src/jobs/labelProperties.tsx
@@ -74,11 +74,6 @@ function LabelProperties({
       ) {
         setLabelDetail([DEFAULT_LABEL_DETAIL]);
         setLabelDetailUpdated([DEFAULT_LABEL_DETAIL]);
-      } else {
-        if (!selectedRuntimeClone) {
-          setLabelDetailUpdated([]);
-          setLabelDetail([]);
-        }
       }
     }
   }, []);
@@ -197,7 +192,7 @@ function LabelProperties({
                   */
             const labelSplit = label.split(':');
             return (
-              <div key={label}>
+              <div key={index}>
                 <div className="job-label-edit-row">
                   <div className="key-message-wrapper">
                     <div className="select-text-overlay-label">
@@ -223,7 +218,9 @@ function LabelProperties({
                         onChange={e =>
                           handleEditLabel(e.target.value, index, 'key')
                         }
-                        defaultValue={labelSplit[0]}
+                        value={
+                          labelDetailUpdated[index] ? labelDetailUpdated[index].split(':')[0] : ''
+                        }
                         Label={`Key ${index + 1}*`}
                       />
                     </div>
@@ -287,10 +284,10 @@ function LabelProperties({
                           buttonText === 'ADD LABEL') || label.startsWith(DATAPROC_TIER_PROPERTY)
                           || label.startsWith(DATAPROC_LIGHTNING_ENGINE_PROPERTY)
                         }
-                        defaultValue={
-                          labelSplit.length > 2
-                            ? label.split(/:(.+)/)[1]
-                            : labelSplit[1]
+                        value={
+                          labelDetailUpdated[index]
+                            ? labelDetailUpdated[index].split(/:(.+)/)[1] || ''
+                            : ''
                         }
                         Label={`Value ${index + 1}`}
                       />

--- a/src/jobs/submitJob.tsx
+++ b/src/jobs/submitJob.tsx
@@ -123,10 +123,10 @@ function SubmitJob({
   const [querySourceTypeList, setQuerySourceTypeList] = useState([{}]);
 
   const [jobIdSelected, setJobIdSelected] = useState('');
-  const [propertyDetail, setPropertyDetail] = useState(['']);
-  const [propertyDetailUpdated, setPropertyDetailUpdated] = useState(['']);
-  const [parameterDetail, setParameterDetail] = useState(['']);
-  const [parameterDetailUpdated, setParameterDetailUpdated] = useState(['']);
+  const [propertyDetail, setPropertyDetail] = useState<string[]>([]);
+  const [propertyDetailUpdated, setPropertyDetailUpdated] = useState<string[]>([]);
+  const [parameterDetail, setParameterDetail] = useState<string[]>([]);
+  const [parameterDetailUpdated, setParameterDetailUpdated] = useState<string[]>([]);
   const [hexNumber, setHexNumber] = useState('');
   const [submitDisabled, setSubmitDisabled] = useState(true);
   let mainJarFileUri = '';

--- a/src/runtime/createRunTime.tsx
+++ b/src/runtime/createRunTime.tsx
@@ -156,8 +156,8 @@ function CreateRunTime({
   const [expandAutoScaling, setExpandAutoScaling] = useState(false);
   const [expandGpu, setExpandGpu] = useState(false);
   const [gpuChecked, setGpuChecked] = useState(false);
-  const [propertyDetail, setPropertyDetail] = useState<string[]>([]);
-  const [propertyDetailUpdated, setPropertyDetailUpdated] = useState<string[]>([]);
+  const [propertyDetail, setPropertyDetail] = useState<string[]>([`${DATAPROC_LIGHTNING_ENGINE_PROPERTY}:default`]);
+  const [propertyDetailUpdated, setPropertyDetailUpdated] = useState<string[]>([`${DATAPROC_LIGHTNING_ENGINE_PROPERTY}:default`]);
   const [keyValidation, setKeyValidation] = useState(-1);
   const [valueValidation, setValueValidation] = useState(-1);
   const [sparkValueValidation, setSparkValueValidation] = useState({
@@ -266,7 +266,7 @@ function CreateRunTime({
   const [apiDialogOpen, setApiDialogOpen] = useState(false);
   const [lightningEngineEnabled, setLightningEngineEnabled] = useState(false);
   const [enableLink, setEnableLink] = useState('');
-  const [othersList , setOthersList] = useState<string[]>([]);
+
   const runtimeOptions = [
     {
       value: '2.3',
@@ -286,19 +286,19 @@ function CreateRunTime({
     }
   ];
 
-  const updateLightningEngineProperty = (currentOthersList = othersList) => {
-    const lightningProperty = DATAPROC_LIGHTNING_ENGINE_PROPERTY + ":" + (lightningEngineEnabled
-    ? 'lightningEngine'
-    : 'default');
-  
-    const updatedProperties = [lightningProperty, ...currentOthersList];
-    setPropertyDetailUpdated(updatedProperties);
-    return updatedProperties;
-  }
-
   useEffect(() => {
-    updateLightningEngineProperty();
-  }, [lightningEngineEnabled,othersList]);
+    setPropertyDetailUpdated(prev => {
+      const lightningProperty = DATAPROC_LIGHTNING_ENGINE_PROPERTY + ":" + (lightningEngineEnabled ? 'lightningEngine' : 'default');
+      const newList = [...prev];
+      const index = newList.findIndex(prop => prop.startsWith(DATAPROC_LIGHTNING_ENGINE_PROPERTY + ':'));
+      if (index !== -1) {
+        newList[index] = lightningProperty;
+      } else {
+        newList.unshift(lightningProperty);
+      }
+      return newList;
+    });
+  }, [lightningEngineEnabled]);
 
   useEffect(() => {
     const initializeRuntime = async () => {
@@ -318,7 +318,7 @@ function CreateRunTime({
           listNetworksAPI();
           listKeyRingsAPI();
           runtimeSharedProject();
-          updateLightningEngineProperty(othersList);
+
         } else {
           setConfigLoading(false);
         }
@@ -654,6 +654,8 @@ function CreateRunTime({
             let gpuDetailList: string[] = [];
             let metaStoreDetailList: string[] = [];
             let otherDetailList: string[] = [];
+            let hasLightning = false;
+            let lightningValue = 'default';
             updatedPropertyDetail.forEach(property => {
               if (
                 RESOURCE_ALLOCATION_DEFAULT.some(item => {
@@ -679,9 +681,10 @@ function CreateRunTime({
               } else if (property.startsWith('spark.sql.catalog.')) {
                 metaStoreDetailList.push(property);
               } else if (property.startsWith(DATAPROC_LIGHTNING_ENGINE_PROPERTY)) {
-                const value = property.split(':')[1];
-                setLightningEngineEnabled(value === 'lightningEngine');
-              }  else {
+                lightningValue = property.split(':')[1];
+                setLightningEngineEnabled(lightningValue === 'lightningEngine');
+                hasLightning = true;
+              } else {
                 otherDetailList.push(property);
               }
             });
@@ -691,7 +694,10 @@ function CreateRunTime({
             setAutoScalingDetailUpdated(autoScalingDetailList);
             setMetastoreDetail(metaStoreDetailList);
             setMetastoreDetailUpdated(metaStoreDetailList);
-            setOthersList(otherDetailList);
+            const lightningPropStr = DATAPROC_LIGHTNING_ENGINE_PROPERTY + ":" + (hasLightning ? lightningValue : 'default');
+            otherDetailList.unshift(lightningPropStr);
+            setPropertyDetail(otherDetailList);
+            setPropertyDetailUpdated(otherDetailList);
             if (metaStoreDetailList.length > 0) {
               setMetastoreType('biglake');
               const warehouseProperty = metaStoreDetailList.find(prop =>

--- a/src/runtime/createRunTime.tsx
+++ b/src/runtime/createRunTime.tsx
@@ -149,8 +149,8 @@ function CreateRunTime({
     useState(AUTO_SCALING_DEFAULT);
   const [autoScalingDetailUpdated, setAutoScalingDetailUpdated] =
     useState(AUTO_SCALING_DEFAULT);
-  const [gpuDetail, setGpuDetail] = useState(['']);
-  const [gpuDetailUpdated, setGpuDetailUpdated] = useState(['']);
+  const [gpuDetail, setGpuDetail] = useState<string[]>([]);
+  const [gpuDetailUpdated, setGpuDetailUpdated] = useState<string[]>([]);
   const [expandResourceAllocation, setExpandResourceAllocation] =
     useState(false);
   const [expandAutoScaling, setExpandAutoScaling] = useState(false);

--- a/src/runtime/createRunTime.tsx
+++ b/src/runtime/createRunTime.tsx
@@ -287,8 +287,8 @@ function CreateRunTime({
   ];
 
   useEffect(() => {
-    setPropertyDetailUpdated(prev => {
-      const lightningProperty = DATAPROC_LIGHTNING_ENGINE_PROPERTY + ":" + (lightningEngineEnabled ? 'lightningEngine' : 'default');
+    const updateList = (prev: string[]) => {
+      const lightningProperty = DATAPROC_LIGHTNING_ENGINE_PROPERTY + ':' + (lightningEngineEnabled ? 'lightningEngine' : 'default');
       const newList = [...prev];
       const index = newList.findIndex(prop => prop.startsWith(DATAPROC_LIGHTNING_ENGINE_PROPERTY + ':'));
       if (index !== -1) {
@@ -297,7 +297,9 @@ function CreateRunTime({
         newList.unshift(lightningProperty);
       }
       return newList;
-    });
+    };
+    setPropertyDetailUpdated(prev => updateList(prev));
+    setPropertyDetail(prev => updateList(prev));
   }, [lightningEngineEnabled]);
 
   useEffect(() => {

--- a/src/sessions/sessionDetails.tsx
+++ b/src/sessions/sessionDetails.tsx
@@ -124,7 +124,7 @@ function SessionDetails({
     }
   });
   const [isLoading, setIsLoading] = useState(true);
-  const [labelDetail, setLabelDetail] = useState(['']);
+  const [labelDetail, setLabelDetail] = useState<string[]>([]);
   const timer = useRef<NodeJS.Timeout | undefined>(undefined);
   const [errorView, setErrorView] = useState(false);
   const [selectedEngine, setSelectedEngine] = useState('Default');


### PR DESCRIPTION
Fixes an issue where toggling the "Enable Lightning Engine" checkbox fails to update the spark.dataproc.engine property