### PR TITLE
Add do-not-merge workflow to block labeled PRs

### DIFF
--- a/.github/workflows/do-not-merge.yml
+++ b/.github/workflows/do-not-merge.yml
@@ -1,0 +1,22 @@
+# Blocks a pull request from being merged while it carries the "do-not-merge" label.
+# Add "do-not-merge" (or "DO NOT MERGE") to a PR and this required check will fail;
+# remove the label and it re-runs and passes. Make this check "Required" in the
+# branch protection rule for `main` for the block to actually be enforced.
+
+name: do-not-merge
+
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize, reopened]
+
+jobs:
+  do-not-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if a blocking label is present
+        if: >-
+          contains(github.event.pull_request.labels.*.name, 'do-not-merge') ||
+          contains(github.event.pull_request.labels.*.name, 'DO NOT MERGE')
+        run: |
+          echo "::error::This PR carries a 'do-not-merge' label and is blocked from merging. Remove the label to unblock."
+          exit 1


### PR DESCRIPTION
## What
Adds a GitHub Actions workflow (`.github/workflows/do-not-merge.yml`) that acts as a merge gate driven by a label.

- Fails the `do-not-merge` check whenever a PR carries the **`do-not-merge`** (or **`DO NOT MERGE`**) label.
- Passes (label absent → step skipped → job succeeds) otherwise.
- Re-evaluates on `opened`, `labeled`, `unlabeled`, `synchronize`, and `reopened`, so adding/removing the label flips the status automatically.

## Why
Labels alone don't block merges — GitHub only enforces *required status checks* and *required reviews*. This workflow translates a label into a status check so PRs like #210 ("DO NOT MERGE - testing") can be reliably held open.

## Follow-up to enforce (needs admin)
After this merges, add `do-not-merge` to **Settings → Branches → branch protection for `main` → Require status checks to pass**. Until then the check is advisory (visible but not blocking).

## Security
The only untrusted input (`labels.*.name`) is read inside a GitHub `if:` expression, not interpolated into any shell command; the `run:` block is a static string. No command-injection surface.