### PR TITLE
Refactor Cluster Management APIs to use Google Cloud Python SDK

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -21,17 +21,22 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '18'
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install "hatchling>=1.11.0" "hatch-jupyter-builder>=0.5" "jupyterlab>=3.6.0,<5"
         python -m pip install pytest
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Install package
       run: |
-        python -m pip install -e ".[test]"
+        python -m pip install ".[test]"
     - name: Test with pytest
       run: |
         pytest

--- a/dataproc_jupyter_plugin/controllers/dataproc.py
+++ b/dataproc_jupyter_plugin/controllers/dataproc.py
@@ -1,0 +1,71 @@
+import json
+import tornado
+from jupyter_server.base.handlers import APIHandler
+from dataproc_jupyter_plugin.services.dataproc import DataprocService
+
+class ListClustersController(APIHandler):
+    @tornado.web.authenticated
+    async def get(self):
+        try:
+            page_size = int(self.get_argument("pageSize", 50))
+            page_token = self.get_argument("pageToken", "")
+            service = DataprocService()
+            result = await service.list_clusters(page_size, page_token)
+            self.finish(result)
+        except Exception as e:
+            self.log.exception("Error listing clusters")
+            self.set_status(500)
+            self.finish({"error": {"code": 500, "message": str(e)}})
+
+
+class ClusterDetailController(APIHandler):
+    @tornado.web.authenticated
+    async def get(self):
+        try:
+            cluster_name = self.get_argument("cluster")
+            service = DataprocService()
+            result = await service.get_cluster_details(cluster_name)
+            self.finish(result)
+        except Exception as e:
+            self.log.exception("Error getting cluster details")
+            self.set_status(500)
+            self.finish({"error": {"code": 500, "message": str(e)}})
+
+class StopClusterController(APIHandler):
+    @tornado.web.authenticated
+    async def post(self):
+        try:
+            cluster_name = self.get_argument("cluster")
+            service = DataprocService()
+            result = await service.stop_cluster(cluster_name)
+            self.finish(result)
+        except Exception as e:
+            self.log.exception("Error stopping cluster")
+            self.set_status(500)
+            self.finish({"error": {"code": 500, "message": str(e)}})
+
+class StartClusterController(APIHandler):
+    @tornado.web.authenticated
+    async def post(self):
+        try:
+            cluster_name = self.get_argument("cluster")
+            service = DataprocService()
+            result = await service.start_cluster(cluster_name)
+            self.finish(result)
+        except Exception as e:
+            self.log.exception("Error starting cluster")
+            self.set_status(500)
+            self.finish({"error": {"code": 500, "message": str(e)}})
+
+class DeleteClusterController(APIHandler):
+    @tornado.web.authenticated
+    async def delete(self):
+        try:
+            cluster_name = self.get_argument("cluster")
+            service = DataprocService()
+            result = await service.delete_cluster(cluster_name)
+            self.finish(result)
+        except Exception as e:
+            self.log.exception("Error deleting cluster")
+            self.set_status(500)
+            self.finish({"error": {"code": 500, "message": str(e)}})

--- a/dataproc_jupyter_plugin/controllers/dataproc.py
+++ b/dataproc_jupyter_plugin/controllers/dataproc.py
@@ -1,5 +1,6 @@
 import json
 import tornado
+from google.api_core.exceptions import GoogleAPICallError
 from jupyter_server.base.handlers import APIHandler
 from dataproc_jupyter_plugin.services.dataproc import DataprocService
 
@@ -12,10 +13,18 @@ class ListClustersController(APIHandler):
             service = DataprocService()
             result = await service.list_clusters(page_size, page_token)
             self.finish(result)
+        except GoogleAPICallError as e:
+            self.log.exception("Google API Error listing clusters")
+            self.set_status(e.code)
+            self.finish({"message": str(e), "error": {"code": e.code, "message": str(e)}})
+        except ValueError as e:
+            self.log.exception("Configuration Error")
+            self.set_status(400)
+            self.finish({"message": str(e), "error": {"code": 400, "message": str(e)}})
         except Exception as e:
             self.log.exception("Error listing clusters")
             self.set_status(500)
-            self.finish({"error": {"code": 500, "message": str(e)}})
+            self.finish({"message": str(e), "error": {"code": 500, "message": str(e)}})
 
 
 class ClusterDetailController(APIHandler):
@@ -26,10 +35,18 @@ class ClusterDetailController(APIHandler):
             service = DataprocService()
             result = await service.get_cluster_details(cluster_name)
             self.finish(result)
+        except GoogleAPICallError as e:
+            self.log.exception("Google API Error getting cluster details")
+            self.set_status(e.code)
+            self.finish({"message": str(e), "error": {"code": e.code, "message": str(e)}})
+        except ValueError as e:
+            self.log.exception("Configuration Error")
+            self.set_status(400)
+            self.finish({"message": str(e), "error": {"code": 400, "message": str(e)}})
         except Exception as e:
             self.log.exception("Error getting cluster details")
             self.set_status(500)
-            self.finish({"error": {"code": 500, "message": str(e)}})
+            self.finish({"message": str(e), "error": {"code": 500, "message": str(e)}})
 
 class StopClusterController(APIHandler):
     @tornado.web.authenticated
@@ -39,10 +56,18 @@ class StopClusterController(APIHandler):
             service = DataprocService()
             result = await service.stop_cluster(cluster_name)
             self.finish(result)
+        except GoogleAPICallError as e:
+            self.log.exception("Google API Error stopping cluster")
+            self.set_status(e.code)
+            self.finish({"message": str(e), "error": {"code": e.code, "message": str(e)}})
+        except ValueError as e:
+            self.log.exception("Configuration Error")
+            self.set_status(400)
+            self.finish({"message": str(e), "error": {"code": 400, "message": str(e)}})
         except Exception as e:
             self.log.exception("Error stopping cluster")
             self.set_status(500)
-            self.finish({"error": {"code": 500, "message": str(e)}})
+            self.finish({"message": str(e), "error": {"code": 500, "message": str(e)}})
 
 class StartClusterController(APIHandler):
     @tornado.web.authenticated
@@ -52,10 +77,18 @@ class StartClusterController(APIHandler):
             service = DataprocService()
             result = await service.start_cluster(cluster_name)
             self.finish(result)
+        except GoogleAPICallError as e:
+            self.log.exception("Google API Error starting cluster")
+            self.set_status(e.code)
+            self.finish({"message": str(e), "error": {"code": e.code, "message": str(e)}})
+        except ValueError as e:
+            self.log.exception("Configuration Error")
+            self.set_status(400)
+            self.finish({"message": str(e), "error": {"code": 400, "message": str(e)}})
         except Exception as e:
             self.log.exception("Error starting cluster")
             self.set_status(500)
-            self.finish({"error": {"code": 500, "message": str(e)}})
+            self.finish({"message": str(e), "error": {"code": 500, "message": str(e)}})
 
 class DeleteClusterController(APIHandler):
     @tornado.web.authenticated
@@ -65,7 +98,15 @@ class DeleteClusterController(APIHandler):
             service = DataprocService()
             result = await service.delete_cluster(cluster_name)
             self.finish(result)
+        except GoogleAPICallError as e:
+            self.log.exception("Google API Error deleting cluster")
+            self.set_status(e.code)
+            self.finish({"message": str(e), "error": {"code": e.code, "message": str(e)}})
+        except ValueError as e:
+            self.log.exception("Configuration Error")
+            self.set_status(400)
+            self.finish({"message": str(e), "error": {"code": 400, "message": str(e)}})
         except Exception as e:
             self.log.exception("Error deleting cluster")
             self.set_status(500)
-            self.finish({"error": {"code": 500, "message": str(e)}})
+            self.finish({"message": str(e), "error": {"code": 500, "message": str(e)}})

--- a/dataproc_jupyter_plugin/handlers.py
+++ b/dataproc_jupyter_plugin/handlers.py
@@ -33,7 +33,8 @@ from dataproc_jupyter_plugin import credentials, urls
 from dataproc_jupyter_plugin.commons import constants
 from dataproc_jupyter_plugin.controllers import (
     bigquery,
-    checkApiEnabled
+    checkApiEnabled,
+    dataproc
 )
 from dataproc_jupyter_plugin.controllers.version import (
     LatestVersionController,
@@ -257,6 +258,11 @@ def setup_handlers(web_app):
         "jupyterlabVersion": LatestVersionController,
         "updatePlugin": UpdatePackage,
         "checkApiEnabled": checkApiEnabled.CheckApiController,
+        "listClusters": dataproc.ListClustersController,
+        "clusterDetail": dataproc.ClusterDetailController,
+        "stopCluster": dataproc.StopClusterController,
+        "startCluster": dataproc.StartClusterController,
+        "deleteCluster": dataproc.DeleteClusterController,
     }
     handlers = [(full_path(name), handler) for name, handler in handlersMap.items()]
     web_app.add_handlers(host_pattern, handlers)

--- a/dataproc_jupyter_plugin/services/dataproc.py
+++ b/dataproc_jupyter_plugin/services/dataproc.py
@@ -1,0 +1,91 @@
+import json
+from google.oauth2 import credentials as oauth2
+from google.cloud import dataproc_v1 as dataproc
+from dataproc_jupyter_plugin import credentials
+import proto
+
+class DataprocService:
+    def __init__(self):
+        pass
+
+    async def get_client(self):
+        cached = await credentials.get_cached()
+        access_token = cached.get("access_token")
+        project_id = cached.get("project_id")
+        region_id = cached.get("region_id")
+        
+        cred = oauth2.Credentials(access_token)
+        api_endpoint = f"{region_id}-dataproc.googleapis.com:443"
+        
+        client = dataproc.ClusterControllerAsyncClient(
+            credentials=cred,
+            client_options={"api_endpoint": api_endpoint}
+        )
+        return client, project_id, region_id
+
+    async def list_clusters(self, page_size=50, page_token=""):
+        client, project_id, region_id = await self.get_client()
+        request = dataproc.ListClustersRequest(
+            project_id=project_id,
+            region=region_id,
+            page_size=page_size,
+            page_token=page_token
+        )
+        response = await client.list_clusters(request=request)
+        # response is a pager, we just want the raw page to return next_page_token and clusters
+        page = response.messages[0] if hasattr(response, "messages") else response
+        
+        # Actually, list_clusters returns a pager. We can get the raw response page by doing:
+        # We should use the async pager's raw_page or just iterate. But frontend expects:
+        # { clusters: [...], nextPageToken: "..." }
+        clusters = []
+        async for cluster in response:
+            clusters.append(proto.Message.to_dict(cluster, use_integers_for_enums=False, preserving_proto_field_name=False))
+            if len(clusters) == page_size:
+                break
+        
+        return {
+            "clusters": clusters,
+            "nextPageToken": response.next_page_token
+        }
+
+
+    async def get_cluster_details(self, cluster_name):
+        client, project_id, region_id = await self.get_client()
+        request = dataproc.GetClusterRequest(
+            project_id=project_id,
+            region=region_id,
+            cluster_name=cluster_name
+        )
+        response = await client.get_cluster(request=request)
+        return proto.Message.to_dict(response, use_integers_for_enums=False, preserving_proto_field_name=False)
+
+    async def stop_cluster(self, cluster_name):
+        client, project_id, region_id = await self.get_client()
+        request = dataproc.StopClusterRequest(
+            project_id=project_id,
+            region=region_id,
+            cluster_name=cluster_name
+        )
+        operation = await client.stop_cluster(request=request)
+        return {"status": "stopping", "operationName": operation.operation.name}
+
+    async def start_cluster(self, cluster_name):
+        client, project_id, region_id = await self.get_client()
+        request = dataproc.StartClusterRequest(
+            project_id=project_id,
+            region=region_id,
+            cluster_name=cluster_name
+        )
+        operation = await client.start_cluster(request=request)
+        return {"status": "starting", "operationName": operation.operation.name}
+
+    async def delete_cluster(self, cluster_name):
+        client, project_id, region_id = await self.get_client()
+        request = dataproc.DeleteClusterRequest(
+            project_id=project_id,
+            region=region_id,
+            cluster_name=cluster_name
+        )
+        operation = await client.delete_cluster(request=request)
+        return {"status": "deleting", "operationName": operation.operation.name}

--- a/dataproc_jupyter_plugin/services/dataproc.py
+++ b/dataproc_jupyter_plugin/services/dataproc.py
@@ -10,6 +10,8 @@ class DataprocService:
 
     async def get_client(self):
         cached = await credentials.get_cached()
+        if cached.get("login_error") or cached.get("config_error"):
+            raise ValueError("GCP credentials or configuration (project/region) are missing or invalid.")
         access_token = cached.get("access_token")
         project_id = cached.get("project_id")
         region_id = cached.get("region_id")
@@ -32,21 +34,20 @@ class DataprocService:
             page_token=page_token
         )
         response = await client.list_clusters(request=request)
-        # response is a pager, we just want the raw page to return next_page_token and clusters
-        page = response.messages[0] if hasattr(response, "messages") else response
         
-        # Actually, list_clusters returns a pager. We can get the raw response page by doing:
-        # We should use the async pager's raw_page or just iterate. But frontend expects:
-        # { clusters: [...], nextPageToken: "..." }
         clusters = []
-        async for cluster in response:
-            clusters.append(proto.Message.to_dict(cluster, use_integers_for_enums=False, preserving_proto_field_name=False))
-            if len(clusters) == page_size:
-                break
-        
+        next_page_token = ""
+        async for page in response.pages:
+            clusters = [
+                proto.Message.to_dict(cluster, use_integers_for_enums=False, preserving_proto_field_name=False)
+                for cluster in page
+            ]
+            next_page_token = response.next_page_token
+            break
+            
         return {
             "clusters": clusters,
-            "nextPageToken": response.next_page_token
+            "nextPageToken": next_page_token
         }
 
 

--- a/dataproc_jupyter_plugin/services/dataproc.py
+++ b/dataproc_jupyter_plugin/services/dataproc.py
@@ -35,19 +35,14 @@ class DataprocService:
         )
         response = await client.list_clusters(request=request)
         
-        clusters = []
-        next_page_token = ""
-        async for page in response.pages:
-            clusters = [
-                proto.Message.to_dict(cluster, use_integers_for_enums=False, preserving_proto_field_name=False)
-                for cluster in page
-            ]
-            next_page_token = response.next_page_token
-            break
-            
+        clusters = [
+            proto.Message.to_dict(cluster, use_integers_for_enums=False, preserving_proto_field_name=False)
+            for cluster in response.clusters
+        ]
+        
         return {
             "clusters": clusters,
-            "nextPageToken": next_page_token
+            "nextPageToken": response.next_page_token
         }
 
 

--- a/dataproc_jupyter_plugin/tests/test_dataproc.py
+++ b/dataproc_jupyter_plugin/tests/test_dataproc.py
@@ -1,0 +1,246 @@
+import json
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from dataproc_jupyter_plugin.tests import mocks
+
+
+@pytest.fixture
+def mock_dataproc_service():
+    with patch("dataproc_jupyter_plugin.controllers.dataproc.DataprocService") as mock_service_class:
+        mock_instance = AsyncMock()
+        mock_service_class.return_value = mock_instance
+        yield mock_instance
+
+
+async def test_list_clusters(monkeypatch, jp_fetch, mock_dataproc_service):
+    mocks.patch_mocks(monkeypatch)
+    
+    mock_dataproc_service.list_clusters.return_value = {
+        "clusters": [{"clusterName": "test-cluster"}],
+        "nextPageToken": "token"
+    }
+
+    response = await jp_fetch(
+        "dataproc-plugin",
+        "listClusters",
+        params={
+            "pageSize": "50",
+            "pageToken": "token123",
+        },
+    )
+    assert response.code == 200
+    payload = json.loads(response.body)
+    assert payload == {
+        "clusters": [{"clusterName": "test-cluster"}],
+        "nextPageToken": "token"
+    }
+    mock_dataproc_service.list_clusters.assert_called_once_with(50, "token123")
+
+
+async def test_cluster_detail(monkeypatch, jp_fetch, mock_dataproc_service):
+    mocks.patch_mocks(monkeypatch)
+    
+    mock_dataproc_service.get_cluster_details.return_value = {
+        "clusterName": "test-cluster",
+        "status": {"state": "RUNNING"}
+    }
+
+    response = await jp_fetch(
+        "dataproc-plugin",
+        "clusterDetail",
+        params={
+            "cluster": "test-cluster",
+        },
+    )
+    assert response.code == 200
+    payload = json.loads(response.body)
+    assert payload == {
+        "clusterName": "test-cluster",
+        "status": {"state": "RUNNING"}
+    }
+    mock_dataproc_service.get_cluster_details.assert_called_once_with("test-cluster")
+
+
+async def test_stop_cluster(monkeypatch, jp_fetch, mock_dataproc_service):
+    mocks.patch_mocks(monkeypatch)
+    
+    mock_dataproc_service.stop_cluster.return_value = {
+        "status": "stopping",
+        "operationName": "op-123"
+    }
+
+    response = await jp_fetch(
+        "dataproc-plugin",
+        "stopCluster",
+        method="POST",
+        params={
+            "cluster": "test-cluster",
+        },
+        body=""
+    )
+    assert response.code == 200
+    payload = json.loads(response.body)
+    assert payload == {
+        "status": "stopping",
+        "operationName": "op-123"
+    }
+    mock_dataproc_service.stop_cluster.assert_called_once_with("test-cluster")
+
+
+async def test_start_cluster(monkeypatch, jp_fetch, mock_dataproc_service):
+    mocks.patch_mocks(monkeypatch)
+    
+    mock_dataproc_service.start_cluster.return_value = {
+        "status": "starting",
+        "operationName": "op-123"
+    }
+
+    response = await jp_fetch(
+        "dataproc-plugin",
+        "startCluster",
+        method="POST",
+        params={
+            "cluster": "test-cluster",
+        },
+        body=""
+    )
+    assert response.code == 200
+    payload = json.loads(response.body)
+    assert payload == {
+        "status": "starting",
+        "operationName": "op-123"
+    }
+    mock_dataproc_service.start_cluster.assert_called_once_with("test-cluster")
+
+
+async def test_delete_cluster(monkeypatch, jp_fetch, mock_dataproc_service):
+    mocks.patch_mocks(monkeypatch)
+    
+    mock_dataproc_service.delete_cluster.return_value = {
+        "status": "deleting",
+        "operationName": "op-123"
+    }
+
+    response = await jp_fetch(
+        "dataproc-plugin",
+        "deleteCluster",
+        method="DELETE",
+        params={
+            "cluster": "test-cluster",
+        },
+    )
+    assert response.code == 200
+    payload = json.loads(response.body)
+    assert payload == {
+        "status": "deleting",
+        "operationName": "op-123"
+    }
+    mock_dataproc_service.delete_cluster.assert_called_once_with("test-cluster")
+
+import tornado.httpclient
+
+async def test_list_clusters_error(monkeypatch, jp_fetch, mock_dataproc_service):
+    mocks.patch_mocks(monkeypatch)
+    
+    mock_dataproc_service.list_clusters.side_effect = Exception("Mocked API Error")
+
+    try:
+        response = await jp_fetch(
+            "dataproc-plugin",
+            "listClusters",
+            params={
+                "pageSize": "50",
+                "pageToken": "token123",
+            },
+        )
+    except tornado.httpclient.HTTPClientError as e:
+        assert e.code == 500
+        payload = json.loads(e.response.body)
+        assert payload["error"]["code"] == 500
+        assert payload["error"]["message"] == "Mocked API Error"
+
+
+async def test_cluster_detail_error(monkeypatch, jp_fetch, mock_dataproc_service):
+    mocks.patch_mocks(monkeypatch)
+    
+    mock_dataproc_service.get_cluster_details.side_effect = Exception("Detail API Error")
+
+    try:
+        response = await jp_fetch(
+            "dataproc-plugin",
+            "clusterDetail",
+            params={
+                "cluster": "test-cluster",
+            },
+        )
+    except tornado.httpclient.HTTPClientError as e:
+        assert e.code == 500
+        payload = json.loads(e.response.body)
+        assert payload["error"]["code"] == 500
+        assert payload["error"]["message"] == "Detail API Error"
+
+
+async def test_stop_cluster_error(monkeypatch, jp_fetch, mock_dataproc_service):
+    mocks.patch_mocks(monkeypatch)
+    
+    mock_dataproc_service.stop_cluster.side_effect = Exception("Stop API Error")
+
+    try:
+        response = await jp_fetch(
+            "dataproc-plugin",
+            "stopCluster",
+            method="POST",
+            params={
+                "cluster": "test-cluster",
+            },
+            body=""
+        )
+    except tornado.httpclient.HTTPClientError as e:
+        assert e.code == 500
+        payload = json.loads(e.response.body)
+        assert payload["error"]["code"] == 500
+        assert payload["error"]["message"] == "Stop API Error"
+
+
+async def test_start_cluster_error(monkeypatch, jp_fetch, mock_dataproc_service):
+    mocks.patch_mocks(monkeypatch)
+    
+    mock_dataproc_service.start_cluster.side_effect = Exception("Start API Error")
+
+    try:
+        response = await jp_fetch(
+            "dataproc-plugin",
+            "startCluster",
+            method="POST",
+            params={
+                "cluster": "test-cluster",
+            },
+            body=""
+        )
+    except tornado.httpclient.HTTPClientError as e:
+        assert e.code == 500
+        payload = json.loads(e.response.body)
+        assert payload["error"]["code"] == 500
+        assert payload["error"]["message"] == "Start API Error"
+
+
+async def test_delete_cluster_error(monkeypatch, jp_fetch, mock_dataproc_service):
+    mocks.patch_mocks(monkeypatch)
+    
+    mock_dataproc_service.delete_cluster.side_effect = Exception("Delete API Error")
+
+    try:
+        response = await jp_fetch(
+            "dataproc-plugin",
+            "deleteCluster",
+            method="DELETE",
+            params={
+                "cluster": "test-cluster",
+            },
+        )
+    except tornado.httpclient.HTTPClientError as e:
+        assert e.code == 500
+        payload = json.loads(e.response.body)
+        assert payload["error"]["code"] == 500
+        assert payload["error"]["message"] == "Delete API Error"

--- a/dataproc_jupyter_plugin/tests/test_dataproc.py
+++ b/dataproc_jupyter_plugin/tests/test_dataproc.py
@@ -3,6 +3,7 @@ import pytest
 from unittest.mock import AsyncMock, patch
 
 from dataproc_jupyter_plugin.tests import mocks
+from google.api_core.exceptions import NotFound
 
 
 @pytest.fixture
@@ -164,7 +165,7 @@ async def test_list_clusters_error(monkeypatch, jp_fetch, mock_dataproc_service)
 async def test_cluster_detail_error(monkeypatch, jp_fetch, mock_dataproc_service):
     mocks.patch_mocks(monkeypatch)
     
-    mock_dataproc_service.get_cluster_details.side_effect = Exception("Detail API Error")
+    mock_dataproc_service.get_cluster_details.side_effect = NotFound("Cluster not found")
 
     try:
         response = await jp_fetch(
@@ -175,10 +176,10 @@ async def test_cluster_detail_error(monkeypatch, jp_fetch, mock_dataproc_service
             },
         )
     except tornado.httpclient.HTTPClientError as e:
-        assert e.code == 500
+        assert e.code == 404
         payload = json.loads(e.response.body)
-        assert payload["error"]["code"] == 500
-        assert payload["error"]["message"] == "Detail API Error"
+        assert payload["error"]["code"] == 404
+        assert "Cluster not found" in payload["error"]["message"]
 
 
 async def test_stop_cluster_error(monkeypatch, jp_fetch, mock_dataproc_service):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,8 @@ dependencies = [
     "aiohttp~=3.9.5",
     "google-cloud-storage~=2.18.2",
     "aiofiles>=22.1.0,<23",
-    "scheduler-jupyter-plugin>=0.1.0"
+    "scheduler-jupyter-plugin>=0.1.0",
+    "google-cloud-dataproc>=5.10.2"
 ]
 dynamic = ["version", "description", "authors", "urls", "keywords"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = ["hatchling>=1.5.0", "jupyterlab>=3.6.0,<5", "hatch-nodejs-version", "hatch-jupyter-builder>=0.5"]
-build-backend = "hatch_jupyter_builder.build"
+build-backend = "hatchling.build"
 
 [project]
 name = "dataproc_jupyter_plugin"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["hatchling>=1.5.0", "jupyterlab>=3.6.0,<5", "hatch-nodejs-version"]
-build-backend = "hatchling.build"
+requires = ["hatchling>=1.5.0", "jupyterlab>=3.6.0,<5", "hatch-nodejs-version", "hatch-jupyter-builder>=0.5"]
+build-backend = "hatch_jupyter_builder.build"
 
 [project]
 name = "dataproc_jupyter_plugin"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling>=1.5.0", "jupyterlab>=3.6.0,<5", "hatch-nodejs-version", "hatch-jupyter-builder>=0.5"]
+requires = ["hatchling>=1.11.0", "jupyterlab>=3.6.0,<5", "hatch-nodejs-version", "hatch-jupyter-builder>=0.5", "tomli>=1.2.2; python_version < '3.11'"]
 build-backend = "hatchling.build"
 
 [project]
@@ -32,7 +32,10 @@ dependencies = [
     "google-cloud-storage~=2.18.2",
     "aiofiles>=22.1.0,<23",
     "scheduler-jupyter-plugin>=0.1.0",
-    "google-cloud-dataproc>=5.10.2"
+    "google-cloud-dataproc>=5.10.2",
+    "tomli>=1.2.2; python_version < '3.11'",
+    "importlib-metadata>=4.8.3; python_version < '3.10'",
+    "typing-extensions>=4.0.0; python_version < '3.10'"
 ]
 dynamic = ["version", "description", "authors", "urls", "keywords"]
 
@@ -80,11 +83,11 @@ skip-if-exists = ["dataproc_jupyter_plugin/labextension/static/style.js"]
 
 [tool.hatch.build.hooks.jupyter-builder.build-kwargs]
 build_cmd = "build:prod"
-npm = ["jlpm"]
+npm = ["jlpm", "yarn"]
 
 [tool.hatch.build.hooks.jupyter-builder.editable-build-kwargs]
 build_cmd = "install:extension"
-npm = ["jlpm"]
+npm = ["jlpm", "yarn"]
 source_dir = "src"
 build_dir = "dataproc_jupyter_plugin/labextension"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = ["hatchling>=1.5.0", "jupyterlab>=3.6.0,<5", "hatch-nodejs-version", "hatch-jupyter-builder>=0.5"]
-build-backend = "hatchling.build"
+build-backend = "hatch_jupyter_builder.build"
 
 [project]
 name = "dataproc_jupyter_plugin"

--- a/src/cluster/clusterServices.tsx
+++ b/src/cluster/clusterServices.tsx
@@ -16,16 +16,12 @@
  */
 
 import {
-  API_HEADER_BEARER,
-  API_HEADER_CONTENT_TYPE,
   ClusterStatus,
   HTTP_METHOD,
-  POLLING_TIME_LIMIT,
-  gcpServiceUrls
+  POLLING_TIME_LIMIT
 } from '../utils/const';
 import {
   authApi,
-  loggedFetch,
   getProjectId,
   authenticatedFetch,
   statusValue,
@@ -33,6 +29,7 @@ import {
 } from '../utils/utils';
 import { DataprocLoggingService, LOG_LEVEL } from '../utils/loggingService';
 import { Notification } from '@jupyterlab/apputils';
+import { requestAPI } from '../handler/handler';
 
 interface IClusterRenderData {
   status: { state: ClusterStatus };
@@ -86,13 +83,7 @@ export class ClusterService {
       queryParams.append('pageSize', '50');
       queryParams.append('pageToken', pageToken);
 
-      const response = await authenticatedFetch({
-        uri: 'clusters',
-        regionIdentifier: 'regions',
-        method: HTTP_METHOD.GET,
-        queryParams: queryParams
-      });
-      const formattedResponse = await response.json();
+      const formattedResponse: any = await requestAPI(`listClusters?${queryParams.toString()}`);
       let transformClusterListData = [];
       if (formattedResponse && formattedResponse.clusters) {
         transformClusterListData = formattedResponse.clusters.map(
@@ -181,55 +172,34 @@ export class ClusterService {
     setClusterInfo: (value: IClusterDetailsResponse) => void
   ) => {
     const credentials = await authApi();
-    const { DATAPROC } = await gcpServiceUrls;
     if (credentials) {
       setProjectName(credentials.project_id || '');
-      loggedFetch(
-        `${DATAPROC}/projects/${credentials.project_id}/regions/${credentials.region_id}/clusters/${clusterSelected}`,
-        {
-          method: 'GET',
-          headers: {
-            'Content-Type': API_HEADER_CONTENT_TYPE,
-            Authorization: API_HEADER_BEARER + credentials.access_token
+      requestAPI(`clusterDetail?cluster=${clusterSelected}`)
+        .then((responseResult: any) => {
+          if (responseResult.error && responseResult.error.code === 404) {
+            setErrorView(true);
           }
-        }
-      )
-        .then((response: Response) => {
-          response
-            .json()
-            .then((responseResult: IClusterDetailsResponse) => {
-              if (responseResult.error && responseResult.error.code === 404) {
-                setErrorView(true);
-              }
-              if (responseResult?.error?.code) {
-                Notification.emit(
-                  `Failed to fetch cluster details : ${responseResult?.error?.message}`,
-                  'error',
-                  {
-                    autoClose: 5000
-                  }
-                );
-              }
-              setClusterInfo(responseResult);
-              setIsLoading(false);
-            })
-            .catch((e: Error) => {
-              console.log(e);
-              setIsLoading(false);
-            });
+          if (responseResult?.error?.code) {
+            Notification.emit(
+              `Failed to fetch cluster details : ${responseResult?.error?.message}`,
+              'error',
+              { autoClose: 5000 }
+            );
+          }
+          setClusterInfo(responseResult);
+          setIsLoading(false);
         })
-        .catch((err: Error) => {
+        .catch((err: any) => {
+          console.log(err);
           setIsLoading(false);
           DataprocLoggingService.log(
             'Error listing clusters Details',
             LOG_LEVEL.ERROR
           );
           Notification.emit(
-            `Failed to fetch cluster details : ${err}`,
+            `Failed to fetch cluster details : ${err.message || err}`,
             'error',
-            {
-              autoClose: 5000
-            }
+            { autoClose: 5000 }
           );
         });
     }
@@ -241,12 +211,7 @@ export class ClusterService {
     timer: any
   ) => {
     try {
-      const response = await authenticatedFetch({
-        uri: `clusters/${selectedCluster}`,
-        method: HTTP_METHOD.GET,
-        regionIdentifier: 'regions'
-      });
-      const formattedResponse = await response.json();
+      const formattedResponse: any = await requestAPI(`clusterDetail?cluster=${selectedCluster}`);
 
       if (formattedResponse.status.state === ClusterStatus.STATUS_STOPPED) {
         ClusterService.startClusterApi(selectedCluster);
@@ -284,12 +249,7 @@ export class ClusterService {
     setRestartEnabled(true);
 
     try {
-      const response = await authenticatedFetch({
-        uri: `clusters/${selectedCluster}:stop`,
-        method: HTTP_METHOD.POST,
-        regionIdentifier: 'regions'
-      });
-      const formattedResponse = await response.json();
+      const formattedResponse: any = await requestAPI(`stopCluster?cluster=${selectedCluster}`, { method: 'POST' });
       console.log(formattedResponse);
       listClustersAPI();
       timer.current = setInterval(() => {
@@ -322,48 +282,26 @@ export class ClusterService {
 
   static deleteClusterApi = async (selectedcluster: string) => {
     const credentials = await authApi();
-    const { DATAPROC } = await gcpServiceUrls;
     if (credentials) {
-      loggedFetch(
-        `${DATAPROC}/projects/${credentials.project_id}/regions/${credentials.region_id}/clusters/${selectedcluster}`,
-        {
-          method: 'DELETE',
-          headers: {
-            'Content-Type': API_HEADER_CONTENT_TYPE,
-            Authorization: API_HEADER_BEARER + credentials.access_token
+      requestAPI(`deleteCluster?cluster=${selectedcluster}`, { method: 'DELETE' })
+        .then((responseResult: any) => {
+          if (responseResult?.error?.code) {
+            Notification.emit(
+              `Error deleting cluster : ${responseResult?.error?.message}`,
+              'error',
+              { autoClose: 5000 }
+            );
+          } else {
+            Notification.emit(
+              `Cluster ${selectedcluster} deleted successfully`,
+              'success',
+              { autoClose: 5000 }
+            );
           }
-        }
-      )
-        .then((response: Response) => {
-          response
-            .json()
-            .then(async (responseResult: Response) => {
-              console.log(responseResult);
-              const formattedResponse = await responseResult.json();
-              if (formattedResponse?.error?.code) {
-                Notification.emit(
-                  `Error deleting cluster : ${formattedResponse?.error?.message}`,
-                  'error',
-                  {
-                    autoClose: 5000
-                  }
-                );
-              } else {
-                Notification.emit(
-                  `Cluster ${selectedcluster} deleted successfully`,
-                  'success',
-                  {
-                    autoClose: 5000
-                  }
-                );
-              }
-            })
-            .catch((e: Error) => console.log(e));
         })
-        .catch((err: Error) => {
+        .catch((err: any) => {
           DataprocLoggingService.log('Error deleting cluster', LOG_LEVEL.ERROR);
-
-          Notification.emit(`Error deleting cluster : ${err}`, 'error', {
+          Notification.emit(`Error deleting cluster : ${err.message || err}`, 'error', {
             autoClose: 5000
           });
         });
@@ -375,39 +313,21 @@ export class ClusterService {
     operation: 'start' | 'stop'
   ) => {
     const credentials = await authApi();
-    const { DATAPROC } = await gcpServiceUrls;
     if (credentials) {
-      loggedFetch(
-        `${DATAPROC}/projects/${credentials.project_id}/regions/${credentials.region_id}/clusters/${selectedcluster}:${operation}`,
-        {
-          method: 'POST',
-          headers: {
-            'Content-Type': API_HEADER_CONTENT_TYPE,
-            Authorization: API_HEADER_BEARER + credentials.access_token
+      requestAPI(`${operation}Cluster?cluster=${selectedcluster}`, { method: 'POST' })
+        .then((responseResult: any) => {
+          if (responseResult?.error?.code) {
+            Notification.emit(responseResult?.error?.message, 'error', {
+              autoClose: 5000
+            });
           }
-        }
-      )
-        .then((response: Response) => {
-          response
-            .json()
-            .then(async (responseResult: Response) => {
-              console.log(responseResult);
-              const formattedResponse = await responseResult.json();
-              if (formattedResponse?.error?.code) {
-                Notification.emit(formattedResponse?.error?.message, 'error', {
-                  autoClose: 5000
-                });
-              }
-            })
-            .catch((e: Error) => console.log(e));
         })
-        .catch((err: Error) => {
+        .catch((err: any) => {
           DataprocLoggingService.log(
             `Error ${operation} cluster`,
             LOG_LEVEL.ERROR
           );
-
-          Notification.emit(`Error ${operation} cluster : ${err}`, 'error', {
+          Notification.emit(`Error ${operation} cluster : ${err.message || err}`, 'error', {
             autoClose: 5000
           });
         });

--- a/src/cluster/clusterServices.tsx
+++ b/src/cluster/clusterServices.tsx
@@ -17,13 +17,11 @@
 
 import {
   ClusterStatus,
-  HTTP_METHOD,
   POLLING_TIME_LIMIT
 } from '../utils/const';
 import {
   authApi,
   getProjectId,
-  authenticatedFetch,
   statusValue,
   handleApiError
 } from '../utils/utils';

--- a/src/cluster/clusterServices.tsx
+++ b/src/cluster/clusterServices.tsx
@@ -76,7 +76,6 @@ export class ClusterService {
     try {
       const projectId = await getProjectId();
       setProjectId(projectId);
-      const credentials = await authApi();
       const queryParams = new URLSearchParams();
       queryParams.append('pageSize', '50');
       queryParams.append('pageToken', pageToken);

--- a/src/cluster/clusterServices.tsx
+++ b/src/cluster/clusterServices.tsx
@@ -115,7 +115,7 @@ export class ClusterService {
         ...transformClusterListData
       ];
 
-      if (formattedResponse.nextPageToken) {
+      if (formattedResponse?.nextPageToken) {
         this.listClustersAPIService(
           setProjectId,
           renderActions,
@@ -133,31 +133,19 @@ export class ClusterService {
         setIsLoading(false);
         setLoggedIn(true);
       }
-
-      if (
-        formattedResponse?.error?.code &&
-        !credentials?.login_error &&
-        !credentials?.config_error
-      ) {
-        const credentials = await authApi();
-
+    } catch (error: any) {
+      setIsLoading(false);
+      DataprocLoggingService.log('Error listing clusters', LOG_LEVEL.ERROR);
+      const credentials = await authApi();
+      if (!credentials?.login_error && !credentials?.config_error) {
         handleApiError(
-          formattedResponse,
+          { error: { code: error.response?.status || 500, message: error.message || error } },
           credentials,
           setApiDialogOpen,
           setEnableLink,
           setPollingDisable,
           'clusters'
         );
-      }
-    } catch (error) {
-      setIsLoading(false);
-      DataprocLoggingService.log('Error listing clusters', LOG_LEVEL.ERROR);
-      const credentials = await authApi();
-      if (!credentials?.login_error && !credentials?.config_error) {
-        Notification.emit(`Failed to fetch clusters list : ${error}`, 'error', {
-          autoClose: 5000
-        });
       }
     }
   };
@@ -208,15 +196,6 @@ export class ClusterService {
         ClusterService.startClusterApi(selectedCluster);
         clearInterval(timer.current);
       }
-      if (formattedResponse?.error?.code) {
-        Notification.emit(
-          `Failed to fetch status for cluster ${selectedCluster} : ${formattedResponse?.error?.message}`,
-          'error',
-          {
-            autoClose: 5000
-          }
-        );
-      }
       listClustersAPI();
     } catch (error) {
       DataprocLoggingService.log('Error fetching status', LOG_LEVEL.ERROR);
@@ -246,15 +225,7 @@ export class ClusterService {
       timer.current = setInterval(() => {
         statusApi(selectedCluster);
       }, POLLING_TIME_LIMIT);
-      if (formattedResponse?.error?.code) {
-        Notification.emit(
-          `Failed to restart cluster ${selectedCluster} : ${formattedResponse?.error?.message}`,
-          'error',
-          {
-            autoClose: 5000
-          }
-        );
-      }
+      
       // This is an artifact of the refactoring
       listClustersAPI();
 
@@ -298,13 +269,7 @@ export class ClusterService {
     const credentials = await authApi();
     if (credentials) {
       requestAPI(`${operation}Cluster?cluster=${selectedcluster}`, { method: 'POST' })
-        .then((responseResult: any) => {
-          if (responseResult?.error?.code) {
-            Notification.emit(responseResult?.error?.message, 'error', {
-              autoClose: 5000
-            });
-          }
-        })
+        .then(() => {})
         .catch((err: any) => {
           DataprocLoggingService.log(
             `Error ${operation} cluster`,

--- a/src/cluster/clusterServices.tsx
+++ b/src/cluster/clusterServices.tsx
@@ -174,22 +174,15 @@ export class ClusterService {
       setProjectName(credentials.project_id || '');
       requestAPI(`clusterDetail?cluster=${clusterSelected}`)
         .then((responseResult: any) => {
-          if (responseResult.error && responseResult.error.code === 404) {
-            setErrorView(true);
-          }
-          if (responseResult?.error?.code) {
-            Notification.emit(
-              `Failed to fetch cluster details : ${responseResult?.error?.message}`,
-              'error',
-              { autoClose: 5000 }
-            );
-          }
           setClusterInfo(responseResult);
           setIsLoading(false);
         })
         .catch((err: any) => {
           console.log(err);
           setIsLoading(false);
+          if (err.response && err.response.status === 404) {
+            setErrorView(true);
+          }
           DataprocLoggingService.log(
             'Error listing clusters Details',
             LOG_LEVEL.ERROR
@@ -282,20 +275,12 @@ export class ClusterService {
     const credentials = await authApi();
     if (credentials) {
       requestAPI(`deleteCluster?cluster=${selectedcluster}`, { method: 'DELETE' })
-        .then((responseResult: any) => {
-          if (responseResult?.error?.code) {
-            Notification.emit(
-              `Error deleting cluster : ${responseResult?.error?.message}`,
-              'error',
-              { autoClose: 5000 }
-            );
-          } else {
-            Notification.emit(
-              `Cluster ${selectedcluster} deleted successfully`,
-              'success',
-              { autoClose: 5000 }
-            );
-          }
+        .then(() => {
+          Notification.emit(
+            `Cluster ${selectedcluster} deleted successfully`,
+            'success',
+            { autoClose: 5000 }
+          );
         })
         .catch((err: any) => {
           DataprocLoggingService.log('Error deleting cluster', LOG_LEVEL.ERROR);

--- a/src/runtime/createRunTime.tsx
+++ b/src/runtime/createRunTime.tsx
@@ -114,6 +114,11 @@ const iconHelpDark = new LabIcon({
 let networkUris: string[] = [];
 let key: string[] | (() => string[]) = [];
 let value: string[] | (() => string[]) = [];
+
+const initializeKeysOnly = (defaultArray: string[]) => {
+  return defaultArray.map(item => `${item.split(':')[0]}:`);
+};
+
 function CreateRunTime({
   setOpenCreateTemplate,
   selectedRuntimeClone,
@@ -141,23 +146,23 @@ function CreateRunTime({
     ...networkUris
   ]);
   const [resourceAllocationDetail, setResourceAllocationDetail] = useState(
-    RESOURCE_ALLOCATION_DEFAULT
+    () => selectedRuntimeClone ? RESOURCE_ALLOCATION_DEFAULT : initializeKeysOnly(RESOURCE_ALLOCATION_DEFAULT)
   );
   const [resourceAllocationDetailUpdated, setResourceAllocationDetailUpdated] =
-    useState(RESOURCE_ALLOCATION_DEFAULT);
+    useState(() => selectedRuntimeClone ? RESOURCE_ALLOCATION_DEFAULT : initializeKeysOnly(RESOURCE_ALLOCATION_DEFAULT));
   const [autoScalingDetail, setAutoScalingDetail] =
-    useState(AUTO_SCALING_DEFAULT);
+    useState(() => selectedRuntimeClone ? AUTO_SCALING_DEFAULT : initializeKeysOnly(AUTO_SCALING_DEFAULT));
   const [autoScalingDetailUpdated, setAutoScalingDetailUpdated] =
-    useState(AUTO_SCALING_DEFAULT);
-  const [gpuDetail, setGpuDetail] = useState<string[]>([]);
-  const [gpuDetailUpdated, setGpuDetailUpdated] = useState<string[]>([]);
+    useState(() => selectedRuntimeClone ? AUTO_SCALING_DEFAULT : initializeKeysOnly(AUTO_SCALING_DEFAULT));
+  const [gpuDetail, setGpuDetail] = useState(['']);
+  const [gpuDetailUpdated, setGpuDetailUpdated] = useState(['']);
   const [expandResourceAllocation, setExpandResourceAllocation] =
     useState(false);
   const [expandAutoScaling, setExpandAutoScaling] = useState(false);
   const [expandGpu, setExpandGpu] = useState(false);
   const [gpuChecked, setGpuChecked] = useState(false);
-  const [propertyDetail, setPropertyDetail] = useState<string[]>([`${DATAPROC_LIGHTNING_ENGINE_PROPERTY}:default`]);
-  const [propertyDetailUpdated, setPropertyDetailUpdated] = useState<string[]>([`${DATAPROC_LIGHTNING_ENGINE_PROPERTY}:default`]);
+  const [propertyDetail, setPropertyDetail] = useState<string[]>([]);
+  const [propertyDetailUpdated, setPropertyDetailUpdated] = useState<string[]>([]);
   const [keyValidation, setKeyValidation] = useState(-1);
   const [valueValidation, setValueValidation] = useState(-1);
   const [sparkValueValidation, setSparkValueValidation] = useState({
@@ -221,8 +226,12 @@ function CreateRunTime({
   const [metastoreType, setMetastoreType] = useState('none');
   const [dataWarehouseDir, setDataWarehouseDir] = useState('');
   const [catalogName, setCatalogName] = useState('biglake');
-  const [metastoreDetail, setMetastoreDetail] = useState(META_STORE_DEFAULT);
-  const [metastoreDetailUpdated, setMetastoreDetailUpdated] = useState(META_STORE_DEFAULT);
+  const [metastoreDetail, setMetastoreDetail] = useState(
+    () => selectedRuntimeClone ? META_STORE_DEFAULT : initializeKeysOnly(META_STORE_DEFAULT)
+  );
+  const [metastoreDetailUpdated, setMetastoreDetailUpdated] = useState(
+    () => selectedRuntimeClone ? META_STORE_DEFAULT : initializeKeysOnly(META_STORE_DEFAULT)
+  );
   const gcsUrlRegex = /^gs:\/\/([a-z0-9][a-z0-9_.-]{1,61}[a-z0-9])(\/.*[^\/])?$/;
   const bucketNameRegex = /^(?:gs:\/\/)?([a-z0-9][a-z0-9_.-]{1,61}[a-z0-9])$/;
   const [isValidDataWareHouseUrl, setIsValidDataWareHouseUrl] = useState(false);
@@ -266,7 +275,6 @@ function CreateRunTime({
   const [apiDialogOpen, setApiDialogOpen] = useState(false);
   const [lightningEngineEnabled, setLightningEngineEnabled] = useState(false);
   const [enableLink, setEnableLink] = useState('');
-
   const runtimeOptions = [
     {
       value: '2.3',
@@ -286,20 +294,32 @@ function CreateRunTime({
     }
   ];
 
-  useEffect(() => {
-    const updateList = (prev: string[]) => {
-      const lightningProperty = DATAPROC_LIGHTNING_ENGINE_PROPERTY + ':' + (lightningEngineEnabled ? 'lightningEngine' : 'default');
-      const newList = [...prev];
-      const index = newList.findIndex(prop => prop.startsWith(DATAPROC_LIGHTNING_ENGINE_PROPERTY + ':'));
-      if (index !== -1) {
-        newList[index] = lightningProperty;
-      } else {
-        newList.unshift(lightningProperty);
+  const updateLightningEngineProperty = () => {
+    const lightningKey = DATAPROC_LIGHTNING_ENGINE_PROPERTY;
+
+    setResourceAllocationDetailUpdated(prev => {
+      const cleanList = prev.filter(
+        prop => !prop.startsWith(lightningKey + ':')
+      );
+      if (lightningEngineEnabled) {
+        return [...cleanList, `${lightningKey}:lightningEngine`];
       }
-      return newList;
-    };
-    setPropertyDetailUpdated(prev => updateList(prev));
-    setPropertyDetail(prev => updateList(prev));
+      return cleanList;
+    });
+
+    setResourceAllocationDetail(prev => {
+      const cleanList = prev.filter(
+        prop => !prop.startsWith(lightningKey + ':')
+      );
+      if (lightningEngineEnabled) {
+        return [...cleanList, `${lightningKey}:lightningEngine`];
+      }
+      return cleanList;
+    });
+  };
+
+  useEffect(() => {
+    updateLightningEngineProperty();
   }, [lightningEngineEnabled]);
 
   useEffect(() => {
@@ -320,7 +340,6 @@ function CreateRunTime({
           listNetworksAPI();
           listKeyRingsAPI();
           runtimeSharedProject();
-
         } else {
           setConfigLoading(false);
         }
@@ -343,12 +362,6 @@ function CreateRunTime({
       setLabelDetail(labelDetailUpdated);
     }
   }, [labelDetailUpdated, labelDetail]);
-
-  useEffect(() => {
-    if (propertyDetail.length !== propertyDetailUpdated.length) {
-      setPropertyDetail(propertyDetailUpdated);
-    }
-  }, [propertyDetailUpdated, propertyDetail]);
 
   useEffect(() => {
     if (selectedRuntimeClone === undefined) {
@@ -377,6 +390,65 @@ function CreateRunTime({
     }
   }, [networkSelected]);
 
+  useEffect(() => {
+    if (resourceAllocationDetailUpdated.length > 0) {
+      const structuralCheck = resourceAllocationDetailUpdated.map(item => {
+        const [key, value] = item.split(':');
+        if (value === undefined) return `${key}:`;
+        return item;
+      });
+      if (JSON.stringify(structuralCheck) !== JSON.stringify(resourceAllocationDetailUpdated)) {
+        setResourceAllocationDetail(structuralCheck);
+        setResourceAllocationDetailUpdated(structuralCheck);
+      }
+    }
+  }, [resourceAllocationDetailUpdated]);
+
+  useEffect(() => {
+    if (!gpuChecked || resourceAllocationDetailUpdated.length === 0) return;
+
+    const coresItem = resourceAllocationDetailUpdated.find(item =>
+      item.startsWith('spark.executor.cores:')
+    );
+    if (!coresItem) return;
+
+    const [, value] = coresItem.split(':');
+    const trimmedValue = value ? value.trim() : '';
+    let cores: number;
+
+    if (trimmedValue === '') {
+      const defaultCoresItem = RESOURCE_ALLOCATION_DEFAULT.find(d =>
+        d.startsWith('spark.executor.cores:')
+      );
+      const defaultCoresValue = defaultCoresItem ? defaultCoresItem.split(':')[1] : '4';
+      cores = Number(defaultCoresValue);
+    } else {
+      cores = Number(trimmedValue);
+    }
+
+    if (isNaN(cores) || cores <= 0) {
+      cores = 4;
+    }
+
+    const calculatedGpuValue = (1 / cores).toFixed(2);
+
+    setGpuDetailUpdated(prev => {
+      const updatedGpuState = prev.map(gpuItem => {
+        const [gpuKey] = gpuItem.split(':');
+        if (gpuKey === 'spark.task.resource.gpu.amount') {
+          return `spark.task.resource.gpu.amount:${calculatedGpuValue}`;
+        }
+        return gpuItem;
+      });
+
+      if (JSON.stringify(prev) !== JSON.stringify(updatedGpuState)) {
+        setGpuDetail(updatedGpuState);
+        return updatedGpuState;
+      }
+      return prev;
+    });
+  }, [resourceAllocationDetailUpdated, gpuChecked]);
+
   const modifyResourceAllocation = () => {
     let resourceAllocationModify = [...resourceAllocationDetailUpdated];
     gpuDetailUpdated.forEach(item => {
@@ -385,7 +457,8 @@ function CreateRunTime({
         if (value === 'l4') {
           resourceAllocationModify = resourceAllocationModify
             .map((item: string) => {
-              if (item.includes('spark.dataproc.executor.disk.size')) {
+              const itemKey = item.split(':')[0];
+              if (itemKey === 'spark.dataproc.executor.disk.size') {
                 // To remove the property if GPU checkbox is checked and 'spark.dataproc.executor.resource.accelerator.type:l4'.
                 return null;
               } else if (item === 'spark.executor.cores:12') {
@@ -393,7 +466,8 @@ function CreateRunTime({
               }
               return item;
             })
-            .filter((item): item is string => item !== null); // To filter out null values.'
+            .filter((item): item is string => item !== null); // To filter out null values.
+
           setResourceAllocationDetail(resourceAllocationModify);
           setResourceAllocationDetailUpdated(resourceAllocationModify);
 
@@ -402,9 +476,9 @@ function CreateRunTime({
             const [key] = item.split(':');
             if (key === 'spark.executor.cores') {
               gpuDetailModify = gpuDetailModify.map(gpuItem => {
-                const [gpuKey, value] = gpuItem.split(':');
+                const [gpuKey, val] = gpuItem.split(':');
                 if (gpuKey === 'spark.task.resource.gpu.amount') {
-                  return `spark.task.resource.gpu.amount:${value}`;
+                  return `spark.task.resource.gpu.amount:${val}`;
                 }
                 return gpuItem;
               });
@@ -422,33 +496,30 @@ function CreateRunTime({
               return item;
             })
             .filter((item): item is string => item !== null); // To filter out null values.
-          setResourceAllocationDetail(resourceAllocationModify);
-          setResourceAllocationDetailUpdated(resourceAllocationModify);
 
           if (
-            resourceAllocationModify.filter(property =>
-              property.includes('spark.dataproc.executor.disk.size')
-            ).length === 0
+            !resourceAllocationModify.some(prop =>
+              prop.startsWith('spark.dataproc.executor.disk.size:')
+            )
           ) {
-            // To add the spark.dataproc.executor.disk.size:750g at index 9.
             resourceAllocationModify.splice(
               8,
               0,
-              'spark.dataproc.executor.disk.size:750g'
+              'spark.dataproc.executor.disk.size:'
             );
-            const updatedArray = [...resourceAllocationModify];
-            setResourceAllocationDetail(updatedArray);
-            setResourceAllocationDetailUpdated(updatedArray);
           }
+
+          setResourceAllocationDetail(resourceAllocationModify);
+          setResourceAllocationDetailUpdated(resourceAllocationModify);
 
           let gpuDetailModify = [...gpuDetailUpdated];
           resourceAllocationModify.forEach(item => {
             const [key] = item.split(':');
             if (key === 'spark.executor.cores') {
               gpuDetailModify = gpuDetailModify.map(gpuItem => {
-                const [gpuKey, value] = gpuItem.split(':');
+                const [gpuKey, val] = gpuItem.split(':');
                 if (gpuKey === 'spark.task.resource.gpu.amount') {
-                  return `spark.task.resource.gpu.amount:${value}`;
+                  return `spark.task.resource.gpu.amount:${val}`;
                 }
                 return gpuItem;
               });
@@ -463,6 +534,7 @@ function CreateRunTime({
     setResourceAllocationDetail(resourceAllocationModify);
     setResourceAllocationDetailUpdated(resourceAllocationModify);
   };
+
   useEffect(() => {
     if (
       !gpuDetailChangeDone &&
@@ -523,39 +595,52 @@ function CreateRunTime({
   }, [keyRingSelected]);
 
   useEffect(() => {
-    // filtering the 'spark.dynamicAllocation.enabled' property in the updated state
     const dynamicAllocationState = autoScalingDetailUpdated.find(prop =>
       prop.startsWith('spark.dynamicAllocation.enabled:')
     );
-    if (dynamicAllocationState) {
-      const isEnabled = dynamicAllocationState.endsWith('true');
-      let updatedProperties;
 
-      if (!isEnabled && autoScalingDetailUpdated.length !== 2) {
-        let filteredProperties = [dynamicAllocationState];
+    if (!dynamicAllocationState) return;
+    const val = dynamicAllocationState.split(':')[1];
+    const isEnabled = val ? val === 'true' : true;
 
-        const shuffleEnabledState = autoScalingDetailUpdated.find(
-          (prop) => prop.startsWith('spark.reducer.fetchMigratedShuffle.enabled:')
+    const hasExtraKeys = autoScalingDetailUpdated.some(
+      prop =>
+        !prop.startsWith('spark.dynamicAllocation.enabled:') &&
+        !prop.startsWith('spark.reducer.fetchMigratedShuffle.enabled:')
+    );
+
+    let updatedProperties = null;
+
+    if (!isEnabled && hasExtraKeys) {
+      let filteredProperties = [dynamicAllocationState];
+      const shuffleEnabledState = autoScalingDetailUpdated.find(prop =>
+        prop.startsWith('spark.reducer.fetchMigratedShuffle.enabled:')
+      );
+      if (shuffleEnabledState) {
+        filteredProperties.push(shuffleEnabledState);
+      }
+      updatedProperties = filteredProperties;
+    }
+
+    if (isEnabled && !hasExtraKeys) {
+      updatedProperties = initializeKeysOnly(AUTO_SCALING_DEFAULT);
+
+      updatedProperties = updatedProperties.map(defaultProp => {
+        const defaultKey = defaultProp.split(':')[0];
+        const existingProp = autoScalingDetailUpdated.find(p =>
+          p.startsWith(defaultKey + ':')
         );
+        return existingProp ? existingProp : defaultProp;
+      });
+    }
 
-        if (shuffleEnabledState) {
-          filteredProperties.push(shuffleEnabledState);
-        }
-        updatedProperties = filteredProperties;
-      }
-
-      if (isEnabled && autoScalingDetailUpdated.length == 2) {
-        updatedProperties = AUTO_SCALING_DEFAULT;
-      }
-      if (updatedProperties && JSON.stringify(autoScalingDetailUpdated) !==
-      JSON.stringify(updatedProperties)) {
-        setAutoScalingDetail(updatedProperties);
-        setAutoScalingDetailUpdated(updatedProperties);
-         setSparkValueValidation(prev => ({
-          ...prev,
-          autoscaling: []
-        }));
-      }
+    if (updatedProperties) {
+      setAutoScalingDetail(updatedProperties);
+      setAutoScalingDetailUpdated(updatedProperties);
+      setSparkValueValidation(prev => ({
+        ...prev,
+        autoscaling: []
+      }));
     }
   }, [autoScalingDetailUpdated]);
 
@@ -648,58 +733,76 @@ function CreateRunTime({
           }
 
           if (selectedRuntimeClone.runtimeConfig.hasOwnProperty('properties')) {
-            const updatedPropertyDetail = Object.entries(
-              selectedRuntimeClone.runtimeConfig.properties
-            ).map(([k, v]) => `${k}:${v}`);
-            let resourceAllocationDetailList: string[] = [];
-            let autoScalingDetailList: string[] = [];
-            let gpuDetailList: string[] = [];
+            const incomingProperties = selectedRuntimeClone.runtimeConfig.properties;
+
+            const incomingGpuType = incomingProperties['spark.dataproc.executor.resource.accelerator.type'];
+            const isL4Gpu = incomingGpuType === 'l4';
+
+            const isGpuActiveOnLoad = Object.keys(incomingProperties).some(k => 
+              GPU_DEFAULT.some(i => i.split(':')[0] === k)
+            );
+
+            const resourceAllocationDetailList = RESOURCE_ALLOCATION_DEFAULT.map(item => {
+              const key = item.split(':')[0];
+              const incomingVal = incomingProperties[key];
+
+              if (isGpuActiveOnLoad) {
+                if (key === 'spark.executor.memoryOverhead') {
+                  return null;
+                }
+                if (isL4Gpu && key === 'spark.dataproc.executor.disk.size') {
+                  return null;
+                }
+              }
+
+              return incomingVal !== undefined ? `${key}:${incomingVal}` : `${key}:`;
+            }).filter((item): item is string => item !== null);
+
+            const autoScalingDetailList = AUTO_SCALING_DEFAULT.map(item => {
+              const key = item.split(':')[0];
+              const incomingVal = incomingProperties[key];
+              return incomingVal !== undefined ? `${key}:${incomingVal}` : `${key}:`;
+            });
+
+            const gpuDetailList = GPU_DEFAULT.map(item => {
+              const key = item.split(':')[0];
+              const incomingVal = incomingProperties[key];
+              return incomingVal !== undefined ? `${key}:${incomingVal}` : `${key}:`;
+            });
+
             let metaStoreDetailList: string[] = [];
-            let otherDetailList: string[] = [];
-            let hasLightning = false;
-            let lightningValue = 'default';
-            updatedPropertyDetail.forEach(property => {
-              if (
-                RESOURCE_ALLOCATION_DEFAULT.some(item => {
-                  const [itemKey] = item.split(':');
-                  return itemKey === property.split(':')[0];
-                })
-              ) {
-                resourceAllocationDetailList.push(property);
-              } else if (
-                AUTO_SCALING_DEFAULT.some(item => {
-                  const [itemKey] = item.split(':');
-                  return itemKey === property.split(':')[0];
-                })
-              ) {
-                autoScalingDetailList.push(property);
-              } else if (
-                GPU_DEFAULT.some(item => {
-                  const [itemKey] = item.split(':');
-                  return itemKey === property.split(':')[0];
-                })
-              ) {
-                gpuDetailList.push(property);
-              } else if (property.startsWith('spark.sql.catalog.')) {
-                metaStoreDetailList.push(property);
-              } else if (property.startsWith(DATAPROC_LIGHTNING_ENGINE_PROPERTY)) {
-                lightningValue = property.split(':')[1];
-                setLightningEngineEnabled(lightningValue === 'lightningEngine');
-                hasLightning = true;
-              } else {
-                otherDetailList.push(property);
+            Object.entries(incomingProperties).forEach(([k, v]) => {
+              if (k.startsWith('spark.sql.catalog.')) {
+                metaStoreDetailList.push(`${k}:${v}`);
               }
             });
+
+            let otherDetailList: string[] = [];
+            Object.entries(incomingProperties).forEach(([k, v]) => {
+              const configurationExists = 
+                RESOURCE_ALLOCATION_DEFAULT.some(i => i.split(':')[0] === k) ||
+                AUTO_SCALING_DEFAULT.some(i => i.split(':')[0] === k) ||
+                GPU_DEFAULT.some(i => i.split(':')[0] === k) ||
+                k.startsWith('spark.sql.catalog.') ||
+                k.startsWith(DATAPROC_LIGHTNING_ENGINE_PROPERTY);
+
+              if (!configurationExists) {
+                otherDetailList.push(`${k}:${v}`);
+              }
+            });
+
+            const lightningVal = incomingProperties[DATAPROC_LIGHTNING_ENGINE_PROPERTY];
+            setLightningEngineEnabled(lightningVal === 'lightningEngine');
+
             setResourceAllocationDetail(resourceAllocationDetailList);
             setResourceAllocationDetailUpdated(resourceAllocationDetailList);
             setAutoScalingDetail(autoScalingDetailList);
             setAutoScalingDetailUpdated(autoScalingDetailList);
             setMetastoreDetail(metaStoreDetailList);
             setMetastoreDetailUpdated(metaStoreDetailList);
-            const lightningPropStr = DATAPROC_LIGHTNING_ENGINE_PROPERTY + ":" + (hasLightning ? lightningValue : 'default');
-            otherDetailList.unshift(lightningPropStr);
             setPropertyDetail(otherDetailList);
             setPropertyDetailUpdated(otherDetailList);
+
             if (metaStoreDetailList.length > 0) {
               setMetastoreType('biglake');
               const warehouseProperty = metaStoreDetailList.find(prop =>
@@ -708,38 +811,34 @@ function CreateRunTime({
 
               if (warehouseProperty) {
                 const firstColonIndex = warehouseProperty.indexOf(':');
-                const warehouseUrl = warehouseProperty.substring(
-                  firstColonIndex + 1
-                );
-                const warehouseKey = warehouseProperty.substring(
-                  0,
-                  firstColonIndex
-                );
+                const warehouseUrl = warehouseProperty.substring(firstColonIndex + 1);
+                const warehouseKey = warehouseProperty.substring(0, firstColonIndex);
                 setDataWarehouseDir(warehouseUrl);
                 setIsValidDataWareHouseUrl(gcsUrlRegex.test(warehouseUrl));
                 const keyParts = warehouseKey.split('.');
                 if (keyParts.length > 3) {
-                  const extractedCatalogName = keyParts[3];
-                  setCatalogName(extractedCatalogName);
+                  setCatalogName(keyParts[3]);
                 }
               }
               setExpandMetastore(false);
             } else {
               setMetastoreType('none');
             }
-            if (gpuDetailList.length > 0) {
+
+            const identityGpuPresent = Object.keys(incomingProperties).some(k => 
+              GPU_DEFAULT.some(i => i.split(':')[0] === k)
+            );
+            if (identityGpuPresent) {
               setGpuChecked(true);
               setExpandGpu(true);
-            }
-            if (gpuChecked || gpuDetailList.length > 0) {
               setGpuDetail(gpuDetailList);
               setGpuDetailUpdated(gpuDetailList);
-              setGpuDetailChangeDone(false);
             } else {
-              setGpuDetail(['']);
-              setGpuDetailUpdated(['']);
-              setGpuDetailChangeDone(false);
+              setGpuChecked(false);
+              setGpuDetail(GPU_DEFAULT.map(item => `${item.split(':')[0]}:`));
+              setGpuDetailUpdated(GPU_DEFAULT.map(item => `${item.split(':')[0]}:`));
             }
+            setGpuDetailChangeDone(true);
           }
         }
       }
@@ -1330,42 +1429,42 @@ function CreateRunTime({
         const labelObject: { [key: string]: string } = {};
         labelDetailUpdated.forEach((label: string) => {
           const labelSplit = label.split(':');
-          const key = labelSplit[0];
-          const value = labelSplit[1];
-          labelObject[key] = value;
+          if (labelSplit[0] && labelSplit[1] !== undefined && labelSplit[1].trim() !== '') {
+            labelObject[labelSplit[0]] = labelSplit[1];
+          }
         });
+
         const propertyObject: { [key: string]: string } = {};
-        resourceAllocationDetailUpdated.forEach((label: string) => {
-          const labelSplit = label.split(':');
-          const key = labelSplit[0];
-          const value = labelSplit[1];
-          propertyObject[key] = value;
-        });
-        autoScalingDetailUpdated.forEach((label: string) => {
-          const labelSplit = label.split(':');
-          const key = labelSplit[0];
-          const value = labelSplit[1];
-          propertyObject[key] = value;
-        });
-        gpuDetailUpdated.forEach((label: string) => {
-          const labelSplit = label.split(':');
-          const key = labelSplit[0];
-          const value = labelSplit[1];
-          propertyObject[key] = value;
-        });
-        metastoreType === 'biglake' &&
-        metastoreDetailUpdated.forEach((label: string) => {
-          const firstColonIndex = label.indexOf(':');
-          const key = label.substring(0, firstColonIndex);
-          const value = label.substring(firstColonIndex + 1);
-          propertyObject[key] = value;
-        });
-        propertyDetailUpdated.forEach((label: string) => {
-          const labelSplit = label.split(/:(.+)/);
-          const key = labelSplit[0];
-          const value = labelSplit[1];
-          propertyObject[key] = value;
-        });
+        
+        const appendValidProperties = (
+          propertyArray: string[]
+        ) => {
+          propertyArray.forEach((item: string) => {
+            const firstColon = item.indexOf(':');
+            if (firstColon !== -1) {
+              const key = item.substring(0, firstColon);
+              const value = item.substring(firstColon + 1);
+
+              if (value.trim() !== '') {
+                propertyObject[key] = value.trim();
+              }
+            }
+          });
+        };
+
+        appendValidProperties(resourceAllocationDetailUpdated);
+        appendValidProperties(autoScalingDetailUpdated);
+        
+        if (gpuChecked) {
+          appendValidProperties(gpuDetailUpdated);
+        }
+        
+        if (metastoreType === 'biglake') {
+          appendValidProperties(metastoreDetailUpdated);
+        }
+
+        appendValidProperties(propertyDetailUpdated);
+        
         const inputValueHour = Number(idleTimeSelected) * 3600;
         const inputValueMin = Number(idleTimeSelected) * 60;
         const inputValueHourAuto = Number(autoTimeSelected) * 3600;
@@ -1485,7 +1584,7 @@ function CreateRunTime({
     } catch (error) {
       console.error('Error saving runtime:', error);
     } finally {
-      setIsSaving(false); // Stop loading regardless of success/failure
+      setIsSaving(false);
     }
   };
 
@@ -1507,36 +1606,24 @@ function CreateRunTime({
   const handleGpuCheckbox = (event: React.ChangeEvent<HTMLInputElement>) => {
     setGpuChecked(event.target.checked);
     let gpuDetailModify = [...GPU_DEFAULT];
+
     if (event.target.checked) {
       let resourceAllocationModify = [...resourceAllocationDetailUpdated];
       resourceAllocationModify = resourceAllocationModify
         .map((item: string) => {
-          if (item === 'spark.dataproc.executor.disk.tier:standard') {
+          const key = item.split(':')[0];
+          if (key === 'spark.dataproc.executor.disk.tier') {
             return 'spark.dataproc.executor.disk.tier:premium';
-          } else if (item === 'spark.executor.memoryOverhead:1220m') {
-            // To remove the property if GPU checkbox is checked.
+          } else if (item.startsWith('spark.executor.memoryOverhead')) {
             return null;
           }
           return item;
         })
-        .filter((item): item is string => item !== null); // To filter out null values.
+        .filter((item): item is string => item !== null);
+
       setResourceAllocationDetail(resourceAllocationModify);
       setResourceAllocationDetailUpdated(resourceAllocationModify);
       setExpandGpu(true);
-      resourceAllocationModify.forEach(item => {
-        const [key, value] = item.split(':');
-        if (key === 'spark.executor.cores') {
-          const cores = Number(value);
-          const gpuValue = (1 / cores).toFixed(2);
-          gpuDetailModify = gpuDetailModify.map(gpuItem => {
-            const [gpuKey] = gpuItem.split(':');
-            if (gpuKey === 'spark.task.resource.gpu.amount') {
-              return `spark.task.resource.gpu.amount:${gpuValue}`;
-            }
-            return gpuItem;
-          });
-        }
-      });
       setGpuDetail(gpuDetailModify);
       setGpuDetailUpdated(gpuDetailModify);
       setGpuDetailChangeDone(false);
@@ -1544,42 +1631,40 @@ function CreateRunTime({
       let resourceAllocationModify = [...resourceAllocationDetailUpdated];
       resourceAllocationModify = resourceAllocationModify.map(
         (item: string) => {
-          if (item === 'spark.dataproc.executor.disk.tier:premium') {
-            return 'spark.dataproc.executor.disk.tier:standard';
-          } else if (item.includes('spark.executor.cores')) {
-            return 'spark.executor.cores:4';
+          if (item.startsWith('spark.dataproc.executor.disk.tier:')) {
+            return 'spark.dataproc.executor.disk.tier:';
+          } else if (item.startsWith('spark.executor.cores:')) {
+            return 'spark.executor.cores:';
           }
           return item;
         }
       );
-      if (
-        !resourceAllocationModify.includes(
-          'spark.executor.memoryOverhead:1220m'
-        )
-      ) {
-        // To add the spark.executor.memoryOverhead:1220m at index 8.
+
+      const hasMemoryOverhead = resourceAllocationModify.some(property =>
+        property.startsWith('spark.executor.memoryOverhead:')
+      );
+      if (!hasMemoryOverhead) {
         resourceAllocationModify.splice(
           7,
           0,
-          'spark.executor.memoryOverhead:1220m'
+          'spark.executor.memoryOverhead:'
         );
       }
-      if (
-        resourceAllocationModify.filter(property =>
-          property.includes('spark.dataproc.executor.disk.size')
-        ).length === 0
-      ) {
-        // To add the spark.dataproc.executor.disk.size:400g at index 9 when GPU is unchecked
+
+      const hasDiskSize = resourceAllocationModify.some(property =>
+        property.startsWith('spark.dataproc.executor.disk.size:')
+      );
+      if (!hasDiskSize) {
         resourceAllocationModify.splice(
           8,
           0,
-          'spark.dataproc.executor.disk.size:400g'
+          'spark.dataproc.executor.disk.size:'
         );
       } else {
         resourceAllocationModify = resourceAllocationModify.map(
           (item: string) => {
-            if (item.includes('spark.dataproc.executor.disk.size')) {
-              return 'spark.dataproc.executor.disk.size:400g';
+            if (item.startsWith('spark.dataproc.executor.disk.size:')) {
+              return 'spark.dataproc.executor.disk.size:';
             }
             return item;
           }
@@ -2470,6 +2555,7 @@ function CreateRunTime({
                   setSparkValueValidation={setSparkValueValidation}
                   sparkSection="resourceallocation"
                   setGpuDetailChangeDone={setGpuDetailChangeDone}
+                  defaultSchema={RESOURCE_ALLOCATION_DEFAULT}
                 />
               )}
               <div className="spark-properties-sub-header-parent">
@@ -2512,6 +2598,7 @@ function CreateRunTime({
                   setSparkValueValidation={setSparkValueValidation}
                   sparkSection="autoscaling"
                   setGpuDetailChangeDone={setGpuDetailChangeDone}
+                  defaultSchema={AUTO_SCALING_DEFAULT}
                 />
               )}
               <div className="spark-properties-sub-header-parent">
@@ -2563,6 +2650,7 @@ function CreateRunTime({
                   setSparkValueValidation={setSparkValueValidation}
                   sparkSection="gpu"
                   setGpuDetailChangeDone={setGpuDetailChangeDone}
+                  defaultSchema={GPU_DEFAULT}
                 />
               )}
               {metastoreType === 'biglake' && (
@@ -2607,6 +2695,7 @@ function CreateRunTime({
                       setSparkValueValidation={setSparkValueValidation}
                       sparkSection="metastore"
                       setGpuDetailChangeDone={setGpuDetailChangeDone}
+                      defaultSchema={META_STORE_DEFAULT}
                     />
                   )}
                 </>

--- a/src/runtime/sparkProperties.tsx
+++ b/src/runtime/sparkProperties.tsx
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -19,7 +19,7 @@ import React from 'react';
 import { LabIcon } from '@jupyterlab/ui-components';
 import errorIcon from '../../style/icons/error_icon.svg';
 import { Input } from '../controls/MuiWrappedInput';
-import { Select } from '../controls/MuiWrappedLabelSelect';
+import { TextField, Autocomplete } from '@mui/material';
 import {
   BOOLEAN_SELECT_OPTIONS,
   CORE_RELATED_PROPERTIES,
@@ -43,29 +43,18 @@ function SparkProperties({
   sparkValueValidation,
   setSparkValueValidation,
   sparkSection,
-  setGpuDetailChangeDone
+  defaultSchema = []
 }: any) {
-  /*
-  labelDetail used to store the permanent label details when onblur
-  labelDetailUpdated used to store the temporay label details when onchange
-  */
-
   const handleLabelDetailSelected = (
-    event: React.SyntheticEvent<HTMLElement, Event>,
     data: string,
     index: number
   ) => {
-    const labelEdit = [...labelDetail];
-
-    labelEdit.forEach((labelData, dataNumber: number) => {
-      if (index === dataNumber) {
-        labelData = labelData.replace(
-          labelData.split(':')[1],
-          data!.toString()
-        );
-        labelEdit[dataNumber] = labelData;
-      }
-    });
+    const labelEdit = [...labelDetailUpdated];
+    if (labelEdit[index]) {
+      const parts = labelEdit[index].split(':');
+      parts[1] = data ? data.toString() : '';
+      labelEdit[index] = parts.join(':');
+    }
     setLabelDetail(labelEdit);
     setLabelDetailUpdated(labelEdit);
   };
@@ -76,10 +65,7 @@ function SparkProperties({
 
   const updateErrorIndexes = (index: number, hasError: boolean) => {
     let newErrorIndexes = { ...sparkValueValidation };
-
-    // Ensure deep copy for the specific section
     newErrorIndexes[sparkSection] = [...newErrorIndexes[sparkSection]];
-
     const errorIndex = newErrorIndexes[sparkSection].indexOf(index);
 
     if (hasError && errorIndex === -1) {
@@ -101,98 +87,82 @@ function SparkProperties({
     value = value.replace(DISALLOWED_CHARS_REGEX, '');
     const labelEdit = [...labelDetailUpdated];
 
-    labelEdit.forEach((data, dataNumber: number) => {
-      if (index === dataNumber) {
-        /*
-          allowed aplhanumeric and spaces and underscores values
-        */
-        if (MEMORY_RELATED_PROPERTIES.includes(data.split(':')[0])) {
-          const regex = /^(0*[1-9][0-9]*)(m|g|t)$/i;
+    if (labelEdit[index]) {
+      const parts = labelEdit[index].split(':');
+      const propertyKey = parts[0];
 
-          if (value.search(regex) === -1) {
-            updateErrorIndexes(index, true);
-          } else {
-            updateErrorIndexes(index, false);
-          }
-        } else if (DISK_RELATED_PROPERTIES.includes(data.split(':')[0])) {
-          const regex = /^(0*[1-9][0-9]*)(k|m|g|t)$/i;
+      parts[1] = value;
+      labelEdit[index] = parts.join(':');
 
-          if (value.search(regex) === -1) {
-            updateErrorIndexes(index, true);
-          } else {
-            updateErrorIndexes(index, false);
-          }
-        } else if (CORE_RELATED_PROPERTIES.includes(data.split(':')[0])) {
-          if (
-            value.includes('.') ||
-            !Number.isInteger(Number(value)) ||
-            Number(value) <= 0
-          ) {
-            updateErrorIndexes(index, true);
-          } else {
-            updateErrorIndexes(index, false);
-          }
-        } else if (EXECUTOR_RELATED_PROPERTIES.includes(data.split(':')[0])) {
-          if (
-            value.includes('.') ||
-            !Number.isInteger(Number(value)) ||
-            Number(value) < 2 ||
-            Number(value) > 2000
-          ) {
-            updateErrorIndexes(index, true);
-          } else {
-            updateErrorIndexes(index, false);
-          }
-        } else if (
-          data.split(':')[0] === 'spark.dynamicAllocation.initialExecutors'
-        ) {
-          if (
-            value.includes('.') ||
-            !Number.isInteger(Number(value)) ||
-            Number(value) < 2 ||
-            Number(value) > 500
-          ) {
-            updateErrorIndexes(index, true);
-          } else {
-            updateErrorIndexes(index, false);
-          }
-        } else if (
-          data.split(':')[0] === 'spark.dynamicAllocation.minExecutors'
-        ) {
-          if (
-            value.includes('.') ||
-            !Number.isInteger(Number(value)) ||
-            Number(value) < 2
-          ) {
-            updateErrorIndexes(index, true);
-          } else {
-            updateErrorIndexes(index, false);
-          }
-        } else if (
-          data.split(':')[0] ===
-          'spark.dynamicAllocation.executorAllocationRatio'
-        ) {
-          if (
-            value.length === 0 ||
-            Number.isNaN(Number(value)) ||
-            Number(value) < 0 ||
-            Number(value) > 1
-          ) {
-            updateErrorIndexes(index, true);
-          } else {
-            updateErrorIndexes(index, false);
-          }
-        }
-        /*
-          value is split from labels
-          Example:"client:dataproc_jupyter_plugin"
-          */
-        let sparkProperties = data.split(':');
-        sparkProperties[1] = value.trim();
-        data = sparkProperties[0] + ':' + sparkProperties[1];
+      if (value.trim() === '') {
+        updateErrorIndexes(index, false);
+        setLabelDetailUpdated(labelEdit);
+        return;
       }
-      labelEdit[dataNumber] = data;
-    });
+
+      if (MEMORY_RELATED_PROPERTIES.includes(propertyKey)) {
+        const regex = /^(0*[1-9][0-9]*)(m|g|t)$/i;
+        updateErrorIndexes(index, value.search(regex) === -1);
+      } else if (DISK_RELATED_PROPERTIES.includes(propertyKey)) {
+        const regex = /^(0*[1-9][0-9]*)(k|m|g|t)$/i;
+        updateErrorIndexes(index, value.search(regex) === -1);
+      } else if (CORE_RELATED_PROPERTIES.includes(propertyKey)) {
+        if (
+          value.includes('.') ||
+          !Number.isInteger(Number(value)) ||
+          Number(value) <= 0
+        ) {
+          updateErrorIndexes(index, true);
+        } else {
+          updateErrorIndexes(index, false);
+        }
+      } else if (EXECUTOR_RELATED_PROPERTIES.includes(propertyKey)) {
+        if (
+          value.includes('.') ||
+          !Number.isInteger(Number(value)) ||
+          Number(value) < 2 ||
+          Number(value) > 2000
+        ) {
+          updateErrorIndexes(index, true);
+        } else {
+          updateErrorIndexes(index, false);
+        }
+      } else if (propertyKey === 'spark.dynamicAllocation.initialExecutors') {
+        if (
+          value.includes('.') ||
+          !Number.isInteger(Number(value)) ||
+          Number(value) < 2 ||
+          Number(value) > 500
+        ) {
+          updateErrorIndexes(index, true);
+        } else {
+          updateErrorIndexes(index, false);
+        }
+      } else if (propertyKey === 'spark.dynamicAllocation.minExecutors') {
+        if (
+          value.includes('.') ||
+          !Number.isInteger(Number(value)) ||
+          Number(value) < 2
+        ) {
+          updateErrorIndexes(index, true);
+        } else {
+          updateErrorIndexes(index, false);
+        }
+      } else if (
+        propertyKey === 'spark.dynamicAllocation.executorAllocationRatio'
+      ) {
+        if (
+          value.length === 0 ||
+          Number.isNaN(Number(value)) ||
+          Number(value) < 0 ||
+          Number(value) > 1
+        ) {
+          updateErrorIndexes(index, true);
+        } else {
+          updateErrorIndexes(index, false);
+        }
+      }
+    }
     setLabelDetailUpdated(labelEdit);
   };
 
@@ -201,18 +171,32 @@ function SparkProperties({
       <div className="spark-property-parent">
         {labelDetail.length > 0 &&
           labelDetail.map((label: string, index: number) => {
-            /*
-                     Extracting key, value from label
-                      Example: "{client:dataProc_plugin}"
-                  */
             const labelSplit = label.split(':');
+            const propertyKey = labelSplit[0];
+
+            const draftLabel = labelDetailUpdated[index] || '';
+            const draftColonIndex = draftLabel.indexOf(':');
+            const userValue = draftColonIndex !== -1 ? draftLabel.substring(draftColonIndex + 1) : '';
+
+            const matchDefault = defaultSchema.find((item: string) => item.startsWith(propertyKey + ':'));
+            const placeholderValue = matchDefault ? matchDefault.split(':')[1] : '';
+
+            const isBooleanOption =
+              propertyKey.includes('.enabled') ||
+              userValue === 'true' || userValue === 'false' ||
+              placeholderValue === 'true' || placeholderValue === 'false';
+
+            const currentOptions = isBooleanOption ? BOOLEAN_SELECT_OPTIONS : TIER_SELECT_OPTIONS;
+
+            const selectedOption = currentOptions.find((opt: any) => String(opt.value) === userValue) || null;
+
             return (
-              <div key={label}>
+              <div key={propertyKey}>
                 <div className="job-label-edit-row">
                   <div className="key-message-wrapper">
                     <div
                       className="select-text-overlay-label"
-                      title={labelSplit[0]}
+                      title={propertyKey}
                     >
                       <Input
                         sx={{ margin: 0 }}
@@ -227,33 +211,48 @@ function SparkProperties({
                             'key'
                           )
                         }
-                        defaultValue={labelSplit[0]}
                         Label={`Key ${index + 1}*`}
+                        value={propertyKey}
+                        InputLabelProps={{ shrink: true }}
                       />
                     </div>
                   </div>
                   <div className="key-message-wrapper">
                     <div className="select-text-overlay-label">
-                      {SELECT_FIELDS.includes(labelSplit[0]) &&
-                        sparkSection !== 'gpu' ? (
-                        <Select
-                          className="spark-properties-select-style"
-                          value={labelSplit[1]}
-                          onChange={(e, { value }) =>
-                            handleLabelDetailSelected(e, value as string, index)
+                      {SELECT_FIELDS.includes(propertyKey) &&
+                      sparkSection !== 'gpu' ? (
+                        <Autocomplete
+                          fullWidth
+                          options={currentOptions}
+                          value={selectedOption}
+                          getOptionLabel={(option: any) =>
+                            typeof option === 'string'
+                              ? option
+                              : option.text || option.label || String(option.value)
                           }
-                          options={
-                            labelSplit[1] === 'true' ||
-                              labelSplit[1] === 'false'
-                              ? BOOLEAN_SELECT_OPTIONS
-                              : TIER_SELECT_OPTIONS
-                          }
-                          Label={`Value ${index + 1}`}
+                          onChange={(_event: any, newValue: any) => {
+                            handleLabelDetailSelected(
+                              newValue ? String(newValue.value) : '',
+                              index
+                            );
+                          }}
+                          renderInput={params => (
+                            <TextField
+                              {...params}
+                              variant="outlined"
+                              className="edit-input-style"
+                              label={`Value ${index + 1}`}
+                              placeholder={placeholderValue}
+                              InputLabelProps={{ shrink: true }}
+                            />
+                          )}
                         />
                       ) : (
-                        <Input
-                          sx={{ margin: 0 }}
-                          className={`edit-input-style`}
+                        <TextField
+                          fullWidth
+                          size="medium"
+                          variant="outlined"
+                          className="edit-input-style"
                           onBlur={() => handleEditLabelSwitch()}
                           onChange={e =>
                             handleEditLabel(
@@ -264,18 +263,14 @@ function SparkProperties({
                             )
                           }
                           disabled={
-                            labelSplit[0] ===
+                            propertyKey ===
                               'spark.dataproc.executor.compute.tier' ||
                             (sparkSection === 'metastore' && index === 2)
                           }
-                          value={
-                            labelDetailUpdated[index]
-                              ? labelDetailUpdated[index].substring(
-                                  labelDetailUpdated[index].indexOf(':') + 1
-                                )
-                              : ''
-                          }
-                          Label={`Value ${index + 1}`}
+                          value={userValue}
+                          placeholder={placeholderValue}
+                          label={`Value ${index + 1}`}
+                          InputLabelProps={{ shrink: true }}
                         />
                       )}
                     </div>
@@ -291,7 +286,6 @@ function SparkProperties({
                       </div>
                     )}
                   </div>
-                  <></>
                 </div>
               </div>
             );


### PR DESCRIPTION
Refactor cluster lifecycle operations (list, get, start, stop, delete) to use the official google-cloud-dataproc Python SDK instead of raw REST API calls.