### PR TITLE
Refactor :  startCluster and stopCluster APIs to Python SDK

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -21,17 +21,22 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '18'
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install "hatchling>=1.11.0" "hatch-jupyter-builder>=0.5" "jupyterlab>=3.6.0,<5"
         python -m pip install pytest
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Install package
       run: |
-        python -m pip install -e ".[test]"
+        python -m pip install ".[test]"
     - name: Test with pytest
       run: |
         pytest

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -3,9 +3,6 @@
 
 name: Python package
 
-permissions:
-  contents: read
-
 on:
   push:
     branches: [ "main" ]
@@ -22,9 +19,9 @@ jobs:
         python-version: ["3.10", "3.11"]
 
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b
+      uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -3,6 +3,9 @@
 
 name: Python package
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]
@@ -16,27 +19,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11"]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Set up Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: '18'
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip setuptools wheel
-        python -m pip install "hatchling>=1.11.0" "hatch-jupyter-builder>=0.5" "jupyterlab>=3.6.0,<5"
+        python -m pip install --upgrade pip
         python -m pip install pytest
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Install package
       run: |
-        python -m pip install ".[test]"
+        python -m pip install -e ".[test]"
     - name: Test with pytest
       run: |
         pytest

--- a/dataproc_jupyter_plugin/commons/constants.py
+++ b/dataproc_jupyter_plugin/commons/constants.py
@@ -62,7 +62,7 @@ AIRFLOW_JOB_REGEXP = re.compile("[a-zA-Z0-9_-]+")
 PROJECT_REGEXP = re.compile("^[a-z0-9.:-]+$")
 
 # Region pattern: standard GCP region format
-REGION_REGEXP = re.compile("^[a-z]+-[a-z]+\d+$")
+REGION_REGEXP = re.compile(r"^[a-z]+-[a-z]+\d+$")
 
 # Big Query Client Duration (seconds)
 BQ_CLIENT_EXPIRY_DURATION = 60 * 60  # 1 hour

--- a/dataproc_jupyter_plugin/controllers/dataproc.py
+++ b/dataproc_jupyter_plugin/controllers/dataproc.py
@@ -14,8 +14,13 @@ class StopClusterController(APIHandler):
             self.finish(result)
         except GoogleAPICallError as e:
             self.log.exception("Google API Error stopping cluster")
-            self.set_status(e.code)
-            self.finish({"message": str(e), "error": {"code": e.code, "message": str(e)}})
+            status_code = e.code if isinstance(e.code, int) and 100 <= e.code < 600 else 500
+            self.set_status(status_code)
+            self.finish({"message": str(e), "error": {"code": status_code, "message": str(e)}})
+        except tornado.web.MissingArgumentError as e:
+            self.log.exception("Missing Argument Error")
+            self.set_status(400)
+            self.finish({"message": str(e), "error": {"code": 400, "message": str(e)}})
         except ValueError as e:
             self.log.exception("Configuration Error")
             self.set_status(400)
@@ -35,8 +40,13 @@ class StartClusterController(APIHandler):
             self.finish(result)
         except GoogleAPICallError as e:
             self.log.exception("Google API Error starting cluster")
-            self.set_status(e.code)
-            self.finish({"message": str(e), "error": {"code": e.code, "message": str(e)}})
+            status_code = e.code if isinstance(e.code, int) and 100 <= e.code < 600 else 500
+            self.set_status(status_code)
+            self.finish({"message": str(e), "error": {"code": status_code, "message": str(e)}})
+        except tornado.web.MissingArgumentError as e:
+            self.log.exception("Missing Argument Error")
+            self.set_status(400)
+            self.finish({"message": str(e), "error": {"code": 400, "message": str(e)}})
         except ValueError as e:
             self.log.exception("Configuration Error")
             self.set_status(400)

--- a/dataproc_jupyter_plugin/controllers/dataproc.py
+++ b/dataproc_jupyter_plugin/controllers/dataproc.py
@@ -1,0 +1,47 @@
+import json
+import tornado
+from google.api_core.exceptions import GoogleAPICallError
+from jupyter_server.base.handlers import APIHandler
+from dataproc_jupyter_plugin.services.dataproc import DataprocService
+
+class StopClusterController(APIHandler):
+    @tornado.web.authenticated
+    async def post(self):
+        try:
+            cluster_name = self.get_argument("cluster")
+            service = DataprocService()
+            result = await service.stop_cluster(cluster_name)
+            self.finish(result)
+        except GoogleAPICallError as e:
+            self.log.exception("Google API Error stopping cluster")
+            self.set_status(e.code)
+            self.finish({"message": str(e), "error": {"code": e.code, "message": str(e)}})
+        except ValueError as e:
+            self.log.exception("Configuration Error")
+            self.set_status(400)
+            self.finish({"message": str(e), "error": {"code": 400, "message": str(e)}})
+        except Exception as e:
+            self.log.exception("Error stopping cluster")
+            self.set_status(500)
+            self.finish({"message": str(e), "error": {"code": 500, "message": str(e)}})
+
+class StartClusterController(APIHandler):
+    @tornado.web.authenticated
+    async def post(self):
+        try:
+            cluster_name = self.get_argument("cluster")
+            service = DataprocService()
+            result = await service.start_cluster(cluster_name)
+            self.finish(result)
+        except GoogleAPICallError as e:
+            self.log.exception("Google API Error starting cluster")
+            self.set_status(e.code)
+            self.finish({"message": str(e), "error": {"code": e.code, "message": str(e)}})
+        except ValueError as e:
+            self.log.exception("Configuration Error")
+            self.set_status(400)
+            self.finish({"message": str(e), "error": {"code": 400, "message": str(e)}})
+        except Exception as e:
+            self.log.exception("Error starting cluster")
+            self.set_status(500)
+            self.finish({"message": str(e), "error": {"code": 500, "message": str(e)}})

--- a/dataproc_jupyter_plugin/handlers.py
+++ b/dataproc_jupyter_plugin/handlers.py
@@ -33,7 +33,8 @@ from dataproc_jupyter_plugin import credentials, urls
 from dataproc_jupyter_plugin.commons import constants
 from dataproc_jupyter_plugin.controllers import (
     bigquery,
-    checkApiEnabled
+    checkApiEnabled,
+    dataproc
 )
 from dataproc_jupyter_plugin.controllers.version import (
     LatestVersionController,
@@ -257,6 +258,8 @@ def setup_handlers(web_app):
         "jupyterlabVersion": LatestVersionController,
         "updatePlugin": UpdatePackage,
         "checkApiEnabled": checkApiEnabled.CheckApiController,
+        "stopCluster": dataproc.StopClusterController,
+        "startCluster": dataproc.StartClusterController,
     }
     handlers = [(full_path(name), handler) for name, handler in handlersMap.items()]
     web_app.add_handlers(host_pattern, handlers)

--- a/dataproc_jupyter_plugin/services/dataproc.py
+++ b/dataproc_jupyter_plugin/services/dataproc.py
@@ -1,0 +1,46 @@
+import json
+from google.oauth2 import credentials as oauth2
+from google.cloud import dataproc_v1 as dataproc
+from dataproc_jupyter_plugin import credentials
+import proto
+
+class DataprocService:
+    def __init__(self):
+        pass
+
+    async def get_client(self):
+        cached = await credentials.get_cached()
+        if cached.get("login_error") or cached.get("config_error"):
+            raise ValueError("GCP credentials or configuration (project/region) are missing or invalid.")
+        access_token = cached.get("access_token")
+        project_id = cached.get("project_id")
+        region_id = cached.get("region_id")
+        
+        cred = oauth2.Credentials(access_token)
+        api_endpoint = f"{region_id}-dataproc.googleapis.com:443"
+        
+        client = dataproc.ClusterControllerAsyncClient(
+            credentials=cred,
+            client_options={"api_endpoint": api_endpoint}
+        )
+        return client, project_id, region_id
+
+    async def stop_cluster(self, cluster_name):
+        client, project_id, region_id = await self.get_client()
+        request = dataproc.StopClusterRequest(
+            project_id=project_id,
+            region=region_id,
+            cluster_name=cluster_name
+        )
+        operation = await client.stop_cluster(request=request)
+        return {"status": "stopping", "operationName": operation.operation.name}
+
+    async def start_cluster(self, cluster_name):
+        client, project_id, region_id = await self.get_client()
+        request = dataproc.StartClusterRequest(
+            project_id=project_id,
+            region=region_id,
+            cluster_name=cluster_name
+        )
+        operation = await client.start_cluster(request=request)
+        return {"status": "starting", "operationName": operation.operation.name}

--- a/dataproc_jupyter_plugin/tests/test_dataproc.py
+++ b/dataproc_jupyter_plugin/tests/test_dataproc.py
@@ -72,8 +72,8 @@ async def test_stop_cluster_error(monkeypatch, jp_fetch, mock_dataproc_service):
     
     mock_dataproc_service.stop_cluster.side_effect = Exception("Stop API Error")
 
-    try:
-        response = await jp_fetch(
+    with pytest.raises(tornado.httpclient.HTTPClientError) as exc_info:
+        await jp_fetch(
             "dataproc-plugin",
             "stopCluster",
             method="POST",
@@ -82,11 +82,10 @@ async def test_stop_cluster_error(monkeypatch, jp_fetch, mock_dataproc_service):
             },
             body=""
         )
-    except tornado.httpclient.HTTPClientError as e:
-        assert e.code == 500
-        payload = json.loads(e.response.body)
-        assert payload["error"]["code"] == 500
-        assert payload["error"]["message"] == "Stop API Error"
+    assert exc_info.value.code == 500
+    payload = json.loads(exc_info.value.response.body)
+    assert payload["error"]["code"] == 500
+    assert payload["error"]["message"] == "Stop API Error"
 
 
 async def test_start_cluster_error(monkeypatch, jp_fetch, mock_dataproc_service):
@@ -94,8 +93,8 @@ async def test_start_cluster_error(monkeypatch, jp_fetch, mock_dataproc_service)
     
     mock_dataproc_service.start_cluster.side_effect = Exception("Start API Error")
 
-    try:
-        response = await jp_fetch(
+    with pytest.raises(tornado.httpclient.HTTPClientError) as exc_info:
+        await jp_fetch(
             "dataproc-plugin",
             "startCluster",
             method="POST",
@@ -104,8 +103,7 @@ async def test_start_cluster_error(monkeypatch, jp_fetch, mock_dataproc_service)
             },
             body=""
         )
-    except tornado.httpclient.HTTPClientError as e:
-        assert e.code == 500
-        payload = json.loads(e.response.body)
-        assert payload["error"]["code"] == 500
-        assert payload["error"]["message"] == "Start API Error"
+    assert exc_info.value.code == 500
+    payload = json.loads(exc_info.value.response.body)
+    assert payload["error"]["code"] == 500
+    assert payload["error"]["message"] == "Start API Error"

--- a/dataproc_jupyter_plugin/tests/test_dataproc.py
+++ b/dataproc_jupyter_plugin/tests/test_dataproc.py
@@ -1,0 +1,111 @@
+import json
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from dataproc_jupyter_plugin.tests import mocks
+
+
+@pytest.fixture
+def mock_dataproc_service():
+    with patch("dataproc_jupyter_plugin.controllers.dataproc.DataprocService") as mock_service_class:
+        mock_instance = AsyncMock()
+        mock_service_class.return_value = mock_instance
+        yield mock_instance
+
+
+async def test_stop_cluster(monkeypatch, jp_fetch, mock_dataproc_service):
+    mocks.patch_mocks(monkeypatch)
+    
+    mock_dataproc_service.stop_cluster.return_value = {
+        "status": "stopping",
+        "operationName": "op-123"
+    }
+
+    response = await jp_fetch(
+        "dataproc-plugin",
+        "stopCluster",
+        method="POST",
+        params={
+            "cluster": "test-cluster",
+        },
+        body=""
+    )
+    assert response.code == 200
+    payload = json.loads(response.body)
+    assert payload == {
+        "status": "stopping",
+        "operationName": "op-123"
+    }
+    mock_dataproc_service.stop_cluster.assert_called_once_with("test-cluster")
+
+
+async def test_start_cluster(monkeypatch, jp_fetch, mock_dataproc_service):
+    mocks.patch_mocks(monkeypatch)
+    
+    mock_dataproc_service.start_cluster.return_value = {
+        "status": "starting",
+        "operationName": "op-123"
+    }
+
+    response = await jp_fetch(
+        "dataproc-plugin",
+        "startCluster",
+        method="POST",
+        params={
+            "cluster": "test-cluster",
+        },
+        body=""
+    )
+    assert response.code == 200
+    payload = json.loads(response.body)
+    assert payload == {
+        "status": "starting",
+        "operationName": "op-123"
+    }
+    mock_dataproc_service.start_cluster.assert_called_once_with("test-cluster")
+
+
+import tornado.httpclient
+
+async def test_stop_cluster_error(monkeypatch, jp_fetch, mock_dataproc_service):
+    mocks.patch_mocks(monkeypatch)
+    
+    mock_dataproc_service.stop_cluster.side_effect = Exception("Stop API Error")
+
+    try:
+        response = await jp_fetch(
+            "dataproc-plugin",
+            "stopCluster",
+            method="POST",
+            params={
+                "cluster": "test-cluster",
+            },
+            body=""
+        )
+    except tornado.httpclient.HTTPClientError as e:
+        assert e.code == 500
+        payload = json.loads(e.response.body)
+        assert payload["error"]["code"] == 500
+        assert payload["error"]["message"] == "Stop API Error"
+
+
+async def test_start_cluster_error(monkeypatch, jp_fetch, mock_dataproc_service):
+    mocks.patch_mocks(monkeypatch)
+    
+    mock_dataproc_service.start_cluster.side_effect = Exception("Start API Error")
+
+    try:
+        response = await jp_fetch(
+            "dataproc-plugin",
+            "startCluster",
+            method="POST",
+            params={
+                "cluster": "test-cluster",
+            },
+            body=""
+        )
+    except tornado.httpclient.HTTPClientError as e:
+        assert e.code == 500
+        payload = json.loads(e.response.body)
+        assert payload["error"]["code"] == 500
+        assert payload["error"]["message"] == "Start API Error"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling>=1.5.0", "jupyterlab>=3.6.0,<5", "hatch-nodejs-version"]
+requires = ["hatchling>=1.11.0", "jupyterlab>=3.6.0,<5", "hatch-nodejs-version", "hatch-jupyter-builder>=0.5", "tomli>=1.2.2; python_version < '3.11'"]
 build-backend = "hatchling.build"
 
 [project]
@@ -31,7 +31,11 @@ dependencies = [
     "aiohttp~=3.9.5",
     "google-cloud-storage~=2.18.2",
     "aiofiles>=22.1.0,<23",
-    "scheduler-jupyter-plugin>=0.1.0"
+    "scheduler-jupyter-plugin>=0.1.0",
+    "google-cloud-dataproc>=5.10.2",
+    "tomli>=1.2.2; python_version < '3.11'",
+    "importlib-metadata>=4.8.3; python_version < '3.10'",
+    "typing-extensions>=4.0.0; python_version < '3.10'"
 ]
 dynamic = ["version", "description", "authors", "urls", "keywords"]
 
@@ -79,11 +83,11 @@ skip-if-exists = ["dataproc_jupyter_plugin/labextension/static/style.js"]
 
 [tool.hatch.build.hooks.jupyter-builder.build-kwargs]
 build_cmd = "build:prod"
-npm = ["jlpm"]
+npm = ["jlpm", "yarn"]
 
 [tool.hatch.build.hooks.jupyter-builder.editable-build-kwargs]
 build_cmd = "install:extension"
-npm = ["jlpm"]
+npm = ["jlpm", "yarn"]
 source_dir = "src"
 build_dir = "dataproc_jupyter_plugin/labextension"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [build-system]
-requires = ["hatchling>=1.11.0", "jupyterlab>=3.6.0,<5", "hatch-nodejs-version", "hatch-jupyter-builder>=0.5", "tomli>=1.2.2; python_version < '3.11'"]
+requires = ["hatchling>=1.5.0", "jupyterlab>=3.6.0,<5", "hatch-nodejs-version"]
 build-backend = "hatchling.build"
 
 [project]
 name = "dataproc_jupyter_plugin"
 readme = "README.md"
 license = { file = "LICENSE" }
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 classifiers = [
     "Framework :: Jupyter",
     "Framework :: Jupyter :: JupyterLab",
@@ -16,8 +16,6 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
 ]
@@ -31,11 +29,7 @@ dependencies = [
     "aiohttp~=3.9.5",
     "google-cloud-storage~=2.18.2",
     "aiofiles>=22.1.0,<23",
-    "scheduler-jupyter-plugin>=0.1.0",
-    "google-cloud-dataproc>=5.10.2",
-    "tomli>=1.2.2; python_version < '3.11'",
-    "importlib-metadata>=4.8.3; python_version < '3.10'",
-    "typing-extensions>=4.0.0; python_version < '3.10'"
+    "scheduler-jupyter-plugin>=0.1.0"
 ]
 dynamic = ["version", "description", "authors", "urls", "keywords"]
 
@@ -83,11 +77,11 @@ skip-if-exists = ["dataproc_jupyter_plugin/labextension/static/style.js"]
 
 [tool.hatch.build.hooks.jupyter-builder.build-kwargs]
 build_cmd = "build:prod"
-npm = ["jlpm", "yarn"]
+npm = ["jlpm"]
 
 [tool.hatch.build.hooks.jupyter-builder.editable-build-kwargs]
 build_cmd = "install:extension"
-npm = ["jlpm", "yarn"]
+npm = ["jlpm"]
 source_dir = "src"
 build_dir = "dataproc_jupyter_plugin/labextension"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "dataproc_jupyter_plugin"
 readme = "README.md"
 license = { file = "LICENSE" }
-requires-python = ">=3.10"
+requires-python = ">=3.8"
 classifiers = [
     "Framework :: Jupyter",
     "Framework :: Jupyter :: JupyterLab",
@@ -16,6 +16,8 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "pydantic~=1.10.0",
     "aiohttp~=3.9.5",
     "google-cloud-storage~=2.18.2",
+    "google-cloud-dataproc>=5.0.0",
     "aiofiles>=22.1.0,<23",
     "scheduler-jupyter-plugin>=0.1.0"
 ]

--- a/src/cluster/clusterServices.tsx
+++ b/src/cluster/clusterServices.tsx
@@ -16,23 +16,18 @@
  */
 
 import {
-  API_HEADER_BEARER,
-  API_HEADER_CONTENT_TYPE,
   ClusterStatus,
-  HTTP_METHOD,
-  POLLING_TIME_LIMIT,
-  gcpServiceUrls
+  POLLING_TIME_LIMIT
 } from '../utils/const';
 import {
   authApi,
-  loggedFetch,
   getProjectId,
-  authenticatedFetch,
   statusValue,
   handleApiError
 } from '../utils/utils';
 import { DataprocLoggingService, LOG_LEVEL } from '../utils/loggingService';
 import { Notification } from '@jupyterlab/apputils';
+import { requestAPI } from '../handler/handler';
 
 interface IClusterRenderData {
   status: { state: ClusterStatus };
@@ -81,18 +76,11 @@ export class ClusterService {
     try {
       const projectId = await getProjectId();
       setProjectId(projectId);
-      const credentials = await authApi();
       const queryParams = new URLSearchParams();
       queryParams.append('pageSize', '50');
       queryParams.append('pageToken', pageToken);
 
-      const response = await authenticatedFetch({
-        uri: 'clusters',
-        regionIdentifier: 'regions',
-        method: HTTP_METHOD.GET,
-        queryParams: queryParams
-      });
-      const formattedResponse = await response.json();
+      const formattedResponse: any = await requestAPI(`listClusters?${queryParams.toString()}`);
       let transformClusterListData = [];
       if (formattedResponse && formattedResponse.clusters) {
         transformClusterListData = formattedResponse.clusters.map(
@@ -126,7 +114,7 @@ export class ClusterService {
         ...transformClusterListData
       ];
 
-      if (formattedResponse.nextPageToken) {
+      if (formattedResponse?.nextPageToken) {
         this.listClustersAPIService(
           setProjectId,
           renderActions,
@@ -144,31 +132,19 @@ export class ClusterService {
         setIsLoading(false);
         setLoggedIn(true);
       }
-
-      if (
-        formattedResponse?.error?.code &&
-        !credentials?.login_error &&
-        !credentials?.config_error
-      ) {
-        const credentials = await authApi();
-
+    } catch (error: any) {
+      setIsLoading(false);
+      DataprocLoggingService.log('Error listing clusters', LOG_LEVEL.ERROR);
+      const credentials = await authApi();
+      if (!credentials?.login_error && !credentials?.config_error) {
         handleApiError(
-          formattedResponse,
+          { error: { code: error.response?.status || 500, message: error.message || error } },
           credentials,
           setApiDialogOpen,
           setEnableLink,
           setPollingDisable,
           'clusters'
         );
-      }
-    } catch (error) {
-      setIsLoading(false);
-      DataprocLoggingService.log('Error listing clusters', LOG_LEVEL.ERROR);
-      const credentials = await authApi();
-      if (!credentials?.login_error && !credentials?.config_error) {
-        Notification.emit(`Failed to fetch clusters list : ${error}`, 'error', {
-          autoClose: 5000
-        });
       }
     }
   };
@@ -181,55 +157,27 @@ export class ClusterService {
     setClusterInfo: (value: IClusterDetailsResponse) => void
   ) => {
     const credentials = await authApi();
-    const { DATAPROC } = await gcpServiceUrls;
     if (credentials) {
       setProjectName(credentials.project_id || '');
-      loggedFetch(
-        `${DATAPROC}/projects/${credentials.project_id}/regions/${credentials.region_id}/clusters/${clusterSelected}`,
-        {
-          method: 'GET',
-          headers: {
-            'Content-Type': API_HEADER_CONTENT_TYPE,
-            Authorization: API_HEADER_BEARER + credentials.access_token
-          }
-        }
-      )
-        .then((response: Response) => {
-          response
-            .json()
-            .then((responseResult: IClusterDetailsResponse) => {
-              if (responseResult.error && responseResult.error.code === 404) {
-                setErrorView(true);
-              }
-              if (responseResult?.error?.code) {
-                Notification.emit(
-                  `Failed to fetch cluster details : ${responseResult?.error?.message}`,
-                  'error',
-                  {
-                    autoClose: 5000
-                  }
-                );
-              }
-              setClusterInfo(responseResult);
-              setIsLoading(false);
-            })
-            .catch((e: Error) => {
-              console.log(e);
-              setIsLoading(false);
-            });
-        })
-        .catch((err: Error) => {
+      requestAPI(`clusterDetail?cluster=${clusterSelected}`)
+        .then((responseResult: any) => {
+          setClusterInfo(responseResult);
           setIsLoading(false);
+        })
+        .catch((err: any) => {
+          console.log(err);
+          setIsLoading(false);
+          if (err.response && err.response.status === 404) {
+            setErrorView(true);
+          }
           DataprocLoggingService.log(
             'Error listing clusters Details',
             LOG_LEVEL.ERROR
           );
           Notification.emit(
-            `Failed to fetch cluster details : ${err}`,
+            `Failed to fetch cluster details : ${err.message || err}`,
             'error',
-            {
-              autoClose: 5000
-            }
+            { autoClose: 5000 }
           );
         });
     }
@@ -241,25 +189,11 @@ export class ClusterService {
     timer: any
   ) => {
     try {
-      const response = await authenticatedFetch({
-        uri: `clusters/${selectedCluster}`,
-        method: HTTP_METHOD.GET,
-        regionIdentifier: 'regions'
-      });
-      const formattedResponse = await response.json();
+      const formattedResponse: any = await requestAPI(`clusterDetail?cluster=${selectedCluster}`);
 
       if (formattedResponse.status.state === ClusterStatus.STATUS_STOPPED) {
         ClusterService.startClusterApi(selectedCluster);
         clearInterval(timer.current);
-      }
-      if (formattedResponse?.error?.code) {
-        Notification.emit(
-          `Failed to fetch status for cluster ${selectedCluster} : ${formattedResponse?.error?.message}`,
-          'error',
-          {
-            autoClose: 5000
-          }
-        );
       }
       listClustersAPI();
     } catch (error) {
@@ -284,26 +218,13 @@ export class ClusterService {
     setRestartEnabled(true);
 
     try {
-      const response = await authenticatedFetch({
-        uri: `clusters/${selectedCluster}:stop`,
-        method: HTTP_METHOD.POST,
-        regionIdentifier: 'regions'
-      });
-      const formattedResponse = await response.json();
+      const formattedResponse: any = await requestAPI(`stopCluster?cluster=${selectedCluster}`, { method: 'POST' });
       console.log(formattedResponse);
       listClustersAPI();
       timer.current = setInterval(() => {
         statusApi(selectedCluster);
       }, POLLING_TIME_LIMIT);
-      if (formattedResponse?.error?.code) {
-        Notification.emit(
-          `Failed to restart cluster ${selectedCluster} : ${formattedResponse?.error?.message}`,
-          'error',
-          {
-            autoClose: 5000
-          }
-        );
-      }
+      
       // This is an artifact of the refactoring
       listClustersAPI();
 
@@ -322,48 +243,18 @@ export class ClusterService {
 
   static deleteClusterApi = async (selectedcluster: string) => {
     const credentials = await authApi();
-    const { DATAPROC } = await gcpServiceUrls;
     if (credentials) {
-      loggedFetch(
-        `${DATAPROC}/projects/${credentials.project_id}/regions/${credentials.region_id}/clusters/${selectedcluster}`,
-        {
-          method: 'DELETE',
-          headers: {
-            'Content-Type': API_HEADER_CONTENT_TYPE,
-            Authorization: API_HEADER_BEARER + credentials.access_token
-          }
-        }
-      )
-        .then((response: Response) => {
-          response
-            .json()
-            .then(async (responseResult: Response) => {
-              console.log(responseResult);
-              const formattedResponse = await responseResult.json();
-              if (formattedResponse?.error?.code) {
-                Notification.emit(
-                  `Error deleting cluster : ${formattedResponse?.error?.message}`,
-                  'error',
-                  {
-                    autoClose: 5000
-                  }
-                );
-              } else {
-                Notification.emit(
-                  `Cluster ${selectedcluster} deleted successfully`,
-                  'success',
-                  {
-                    autoClose: 5000
-                  }
-                );
-              }
-            })
-            .catch((e: Error) => console.log(e));
+      requestAPI(`deleteCluster?cluster=${selectedcluster}`, { method: 'DELETE' })
+        .then(() => {
+          Notification.emit(
+            `Cluster ${selectedcluster} deleted successfully`,
+            'success',
+            { autoClose: 5000 }
+          );
         })
-        .catch((err: Error) => {
+        .catch((err: any) => {
           DataprocLoggingService.log('Error deleting cluster', LOG_LEVEL.ERROR);
-
-          Notification.emit(`Error deleting cluster : ${err}`, 'error', {
+          Notification.emit(`Error deleting cluster : ${err.message || err}`, 'error', {
             autoClose: 5000
           });
         });
@@ -375,39 +266,15 @@ export class ClusterService {
     operation: 'start' | 'stop'
   ) => {
     const credentials = await authApi();
-    const { DATAPROC } = await gcpServiceUrls;
     if (credentials) {
-      loggedFetch(
-        `${DATAPROC}/projects/${credentials.project_id}/regions/${credentials.region_id}/clusters/${selectedcluster}:${operation}`,
-        {
-          method: 'POST',
-          headers: {
-            'Content-Type': API_HEADER_CONTENT_TYPE,
-            Authorization: API_HEADER_BEARER + credentials.access_token
-          }
-        }
-      )
-        .then((response: Response) => {
-          response
-            .json()
-            .then(async (responseResult: Response) => {
-              console.log(responseResult);
-              const formattedResponse = await responseResult.json();
-              if (formattedResponse?.error?.code) {
-                Notification.emit(formattedResponse?.error?.message, 'error', {
-                  autoClose: 5000
-                });
-              }
-            })
-            .catch((e: Error) => console.log(e));
-        })
-        .catch((err: Error) => {
+      requestAPI(`${operation}Cluster?cluster=${selectedcluster}`, { method: 'POST' })
+        .then(() => {})
+        .catch((err: any) => {
           DataprocLoggingService.log(
             `Error ${operation} cluster`,
             LOG_LEVEL.ERROR
           );
-
-          Notification.emit(`Error ${operation} cluster : ${err}`, 'error', {
+          Notification.emit(`Error ${operation} cluster : ${err.message || err}`, 'error', {
             autoClose: 5000
           });
         });


### PR DESCRIPTION
Migrates cluster lifecycle state management (`startCluster` and `stopCluster`) from client-side REST calls (`loggedFetch`) to the official `google-cloud-dataproc` Python SDK.