### PR TITLE
Migrate job CRUD and cancel APIs to backend

### DIFF
--- a/dataproc_jupyter_plugin/controllers/jobs.py
+++ b/dataproc_jupyter_plugin/controllers/jobs.py
@@ -1,0 +1,119 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import aiohttp
+import tornado
+from jupyter_server.base.handlers import APIHandler
+from dataproc_jupyter_plugin import credentials
+from dataproc_jupyter_plugin.services.jobs import JobsService
+
+class JobItemController(APIHandler):
+    """Controller for fetching, updating, and deleting a specific Dataproc job."""
+
+    @tornado.web.authenticated
+    async def get(self):
+        try:
+            job_id = self.get_argument("jobId", default=None)
+            if not job_id:
+                self.finish({"error": {"code": 400, "message": "Missing required parameter: jobId"}})
+                return
+
+            creds = await credentials.get_cached()
+            async with aiohttp.ClientSession() as session:
+                service = JobsService(creds, self.log, session)
+                result = await service.get_job(job_id)
+            self.finish(json.dumps(result))
+        except ValueError as e:
+            self.log.warning(f"Validation error in JobItemController GET: {e}")
+            self.finish({"error": {"code": 400, "message": str(e)}})
+        except Exception as e:
+            self.log.exception("Unexpected error in JobItemController GET")
+            self.finish({"error": {"code": 500, "message": f"Server error: {str(e)}"}} if not self._finished else None)
+
+    @tornado.web.authenticated
+    async def patch(self):
+        try:
+            job_id = self.get_argument("jobId", default=None)
+            if not job_id:
+                self.finish({"error": {"code": 400, "message": "Missing required parameter: jobId"}})
+                return
+
+            update_mask = self.get_argument("updateMask", default="labels")
+            try:
+                payload = self.get_json_body()
+            except Exception as json_err:
+                self.log.warning(f"Invalid JSON body in JobItemController PATCH: {json_err}")
+                self.finish({"error": {"code": 400, "message": "Invalid JSON request body."}})
+                return
+
+            if not payload or not isinstance(payload, dict):
+                self.finish({"error": {"code": 400, "message": "Missing or empty update payload."}})
+                return
+
+            creds = await credentials.get_cached()
+            async with aiohttp.ClientSession() as session:
+                service = JobsService(creds, self.log, session)
+                result = await service.update_job(job_id, payload, update_mask)
+            self.finish(json.dumps(result))
+        except ValueError as e:
+            self.log.warning(f"Validation error in JobItemController PATCH: {e}")
+            self.finish({"error": {"code": 400, "message": str(e)}})
+        except Exception as e:
+            self.log.exception("Unexpected error in JobItemController PATCH")
+            self.finish({"error": {"code": 500, "message": f"Server error: {str(e)}"}} if not self._finished else None)
+
+    @tornado.web.authenticated
+    async def delete(self):
+        try:
+            job_id = self.get_argument("jobId", default=None)
+            if not job_id:
+                self.finish({"error": {"code": 400, "message": "Missing required parameter: jobId"}})
+                return
+
+            creds = await credentials.get_cached()
+            async with aiohttp.ClientSession() as session:
+                service = JobsService(creds, self.log, session)
+                result = await service.delete_job(job_id)
+            self.finish(json.dumps(result))
+        except ValueError as e:
+            self.log.warning(f"Validation error in JobItemController DELETE: {e}")
+            self.finish({"error": {"code": 400, "message": str(e)}})
+        except Exception as e:
+            self.log.exception("Unexpected error in JobItemController DELETE")
+            self.finish({"error": {"code": 500, "message": f"Server error: {str(e)}"}} if not self._finished else None)
+
+
+class JobCancelController(APIHandler):
+    """Controller for canceling a Dataproc job."""
+
+    @tornado.web.authenticated
+    async def post(self):
+        try:
+            job_id = self.get_argument("jobId", default=None)
+            if not job_id:
+                self.finish({"error": {"code": 400, "message": "Missing required parameter: jobId"}})
+                return
+
+            creds = await credentials.get_cached()
+            async with aiohttp.ClientSession() as session:
+                service = JobsService(creds, self.log, session)
+                result = await service.cancel_job(job_id)
+            self.finish(json.dumps(result))
+        except ValueError as e:
+            self.log.warning(f"Validation error in JobCancelController POST: {e}")
+            self.finish({"error": {"code": 400, "message": str(e)}})
+        except Exception as e:
+            self.log.exception("Unexpected error in JobCancelController POST")
+            self.finish({"error": {"code": 500, "message": f"Server error: {str(e)}"}} if not self._finished else None)

--- a/dataproc_jupyter_plugin/handlers.py
+++ b/dataproc_jupyter_plugin/handlers.py
@@ -33,7 +33,8 @@ from dataproc_jupyter_plugin import credentials, urls
 from dataproc_jupyter_plugin.commons import constants
 from dataproc_jupyter_plugin.controllers import (
     bigquery,
-    checkApiEnabled
+    checkApiEnabled,
+    jobs
 )
 from dataproc_jupyter_plugin.controllers.version import (
     LatestVersionController,
@@ -257,6 +258,8 @@ def setup_handlers(web_app):
         "jupyterlabVersion": LatestVersionController,
         "updatePlugin": UpdatePackage,
         "checkApiEnabled": checkApiEnabled.CheckApiController,
+        "jobItem": jobs.JobItemController,
+        "jobCancel": jobs.JobCancelController,
     }
     handlers = [(full_path(name), handler) for name, handler in handlersMap.items()]
     web_app.add_handlers(host_pattern, handlers)

--- a/dataproc_jupyter_plugin/services/jobs.py
+++ b/dataproc_jupyter_plugin/services/jobs.py
@@ -57,6 +57,8 @@ class JobsService:
     async def get_base_url(self):
         try:
             dataproc_url = await urls.gcp_service_url(DATAPROC_SERVICE_NAME)
+            if not dataproc_url.endswith("/"):
+                dataproc_url += "/"
             return f"{dataproc_url}v1/projects/{self.project_id}/regions/{self.region_id}/jobs"
         except Exception as e:
             self.log.exception("Failed to resolve Dataproc service URL")
@@ -65,11 +67,15 @@ class JobsService:
     async def _parse_response(self, response, operation_name):
         """Helper method to safely parse HTTP response from Dataproc API."""
         try:
+            if response.status == 204:
+                return {}
             try:
                 res_json = await response.json()
                 return res_json
             except (aiohttp.ContentTypeError, json.JSONDecodeError):
                 raw_text = await response.text()
+                if response.status == 200 and not raw_text.strip():
+                    return {}
                 self.log.warning(
                     f"Non-JSON response received during {operation_name} (HTTP {response.status}): {raw_text}"
                 )

--- a/dataproc_jupyter_plugin/services/jobs.py
+++ b/dataproc_jupyter_plugin/services/jobs.py
@@ -1,0 +1,182 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import asyncio
+import aiohttp
+from dataproc_jupyter_plugin import urls
+from dataproc_jupyter_plugin.commons.constants import (
+    CONTENT_TYPE,
+    DATAPROC_SERVICE_NAME,
+)
+
+
+class JobsService:
+    """Service class to handle Dataproc Job REST API operations."""
+
+    def __init__(self, credentials, log, client_session):
+        self.log = log
+        if not credentials:
+            self.log.error("Credentials object is None or empty")
+            raise ValueError("Authentication credentials are missing or invalid.")
+
+        if not (
+            credentials.get("access_token")
+            and credentials.get("project_id")
+            and credentials.get("region_id")
+        ):
+            missing = [
+                k for k in ["access_token", "project_id", "region_id"]
+                if not credentials.get(k)
+            ]
+            self.log.error(f"Missing required credential fields: {missing}")
+            raise ValueError(f"Missing required credential fields: {', '.join(missing)}")
+
+        self._access_token = credentials["access_token"]
+        self.project_id = credentials["project_id"]
+        self.region_id = credentials["region_id"]
+        self.client_session = client_session
+
+    def create_headers(self):
+        return {
+            "Content-Type": CONTENT_TYPE,
+            "Authorization": f"Bearer {self._access_token}",
+        }
+
+    async def get_base_url(self):
+        try:
+            dataproc_url = await urls.gcp_service_url(DATAPROC_SERVICE_NAME)
+            return f"{dataproc_url}v1/projects/{self.project_id}/regions/{self.region_id}/jobs"
+        except Exception as e:
+            self.log.exception("Failed to resolve Dataproc service URL")
+            raise RuntimeError(f"Failed to resolve Dataproc service URL: {str(e)}") from e
+
+    async def _parse_response(self, response, operation_name):
+        """Helper method to safely parse HTTP response from Dataproc API."""
+        try:
+            try:
+                res_json = await response.json()
+                return res_json
+            except (aiohttp.ContentTypeError, json.JSONDecodeError):
+                raw_text = await response.text()
+                self.log.warning(
+                    f"Non-JSON response received during {operation_name} (HTTP {response.status}): {raw_text}"
+                )
+                if response.status != 200:
+                    return {
+                        "error": {
+                            "code": response.status,
+                            "message": f"HTTP {response.status} {response.reason}: {raw_text}",
+                        }
+                    }
+                return {
+                    "error": {
+                        "code": 500,
+                        "message": f"Failed to parse server response as JSON during {operation_name}.",
+                    }
+                }
+        except Exception as e:
+            self.log.exception(f"Error parsing response during {operation_name}")
+            return {
+                "error": {
+                    "code": 500,
+                    "message": f"Response processing error during {operation_name}: {str(e)}",
+                }
+            }
+
+    async def get_job(self, job_id):
+        """Get details for a specific Dataproc job."""
+        if not job_id:
+            return {"error": {"code": 400, "message": "Job ID must not be empty."}}
+        try:
+            base_url = await self.get_base_url()
+            url = f"{base_url}/{job_id}"
+            async with self.client_session.get(
+                url, headers=self.create_headers()
+            ) as response:
+                return await self._parse_response(response, f"get_job({job_id})")
+        except aiohttp.ClientError as e:
+            self.log.exception(f"HTTP network error while fetching job {job_id}: {e}")
+            return {"error": {"code": 503, "message": f"Network error connecting to Dataproc API: {str(e)}"}}
+        except asyncio.TimeoutError:
+            self.log.exception(f"Timeout error while fetching job {job_id}")
+            return {"error": {"code": 504, "message": f"Request to fetch job {job_id} timed out."}}
+        except Exception as e:
+            self.log.exception(f"Unexpected error fetching details for job {job_id}: {e}")
+            return {"error": {"code": 500, "message": f"Unexpected error fetching job details: {str(e)}"}}
+
+    async def update_job(self, job_id, payload, update_mask="labels"):
+        """Update an existing Dataproc job."""
+        if not job_id:
+            return {"error": {"code": 400, "message": "Job ID must not be empty."}}
+        if not payload or not isinstance(payload, dict):
+            return {"error": {"code": 400, "message": "Invalid or missing job payload."}}
+        try:
+            base_url = await self.get_base_url()
+            url = f"{base_url}/{job_id}?updateMask={update_mask}"
+            async with self.client_session.patch(
+                url, headers=self.create_headers(), data=json.dumps(payload)
+            ) as response:
+                return await self._parse_response(response, f"update_job({job_id})")
+        except aiohttp.ClientError as e:
+            self.log.exception(f"HTTP network error while updating job {job_id}: {e}")
+            return {"error": {"code": 503, "message": f"Network error updating job: {str(e)}"}}
+        except asyncio.TimeoutError:
+            self.log.exception(f"Timeout error while updating job {job_id}")
+            return {"error": {"code": 504, "message": f"Request to update job {job_id} timed out."}}
+        except Exception as e:
+            self.log.exception(f"Unexpected error updating job {job_id}: {e}")
+            return {"error": {"code": 500, "message": f"Unexpected error updating job: {str(e)}"}}
+
+    async def delete_job(self, job_id):
+        """Delete a Dataproc job."""
+        if not job_id:
+            return {"error": {"code": 400, "message": "Job ID must not be empty."}}
+        try:
+            base_url = await self.get_base_url()
+            url = f"{base_url}/{job_id}"
+            async with self.client_session.delete(
+                url, headers=self.create_headers()
+            ) as response:
+                return await self._parse_response(response, f"delete_job({job_id})")
+        except aiohttp.ClientError as e:
+            self.log.exception(f"HTTP network error while deleting job {job_id}: {e}")
+            return {"error": {"code": 503, "message": f"Network error deleting job: {str(e)}"}}
+        except asyncio.TimeoutError:
+            self.log.exception(f"Timeout error while deleting job {job_id}")
+            return {"error": {"code": 504, "message": f"Request to delete job {job_id} timed out."}}
+        except Exception as e:
+            self.log.exception(f"Unexpected error deleting job {job_id}: {e}")
+            return {"error": {"code": 500, "message": f"Unexpected error deleting job: {str(e)}"}}
+
+    async def cancel_job(self, job_id):
+        """Cancel a running Dataproc job."""
+        if not job_id:
+            return {"error": {"code": 400, "message": "Job ID must not be empty."}}
+        try:
+            base_url = await self.get_base_url()
+            url = f"{base_url}/{job_id}:cancel"
+            async with self.client_session.post(
+                url, headers=self.create_headers()
+            ) as response:
+                return await self._parse_response(response, f"cancel_job({job_id})")
+        except aiohttp.ClientError as e:
+            self.log.exception(f"HTTP network error while canceling job {job_id}: {e}")
+            return {"error": {"code": 503, "message": f"Network error canceling job: {str(e)}"}}
+        except asyncio.TimeoutError:
+            self.log.exception(f"Timeout error while canceling job {job_id}")
+            return {"error": {"code": 504, "message": f"Request to cancel job {job_id} timed out."}}
+        except Exception as e:
+            self.log.exception(f"Unexpected error canceling job {job_id}: {e}")
+            return {"error": {"code": 500, "message": f"Unexpected error canceling job: {str(e)}"}}

--- a/dataproc_jupyter_plugin/tests/test_job.py
+++ b/dataproc_jupyter_plugin/tests/test_job.py
@@ -1,0 +1,565 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import pytest
+import aiohttp
+import asyncio
+from unittest.mock import AsyncMock, patch, Mock
+
+from dataproc_jupyter_plugin.services.jobs import JobsService
+from dataproc_jupyter_plugin.commons.constants import DATAPROC_SERVICE_NAME
+
+
+@pytest.fixture
+def mock_credentials():
+    return {
+        "access_token": "test-access-token",
+        "project_id": "test-project-123",
+        "region_id": "us-central1",
+    }
+
+
+@pytest.fixture
+def mock_log():
+    return Mock()
+
+
+@pytest.fixture
+def mock_client_session():
+    return AsyncMock(spec=aiohttp.ClientSession)
+
+def test_jobs_service_init_success(mock_credentials, mock_log, mock_client_session):
+    service = JobsService(mock_credentials, mock_log, mock_client_session)
+    assert service.project_id == "test-project-123"
+    assert service.region_id == "us-central1"
+    assert service._access_token == "test-access-token"
+
+
+def test_jobs_service_init_missing_credentials_none(mock_log, mock_client_session):
+    with pytest.raises(ValueError, match="Authentication credentials are missing or invalid"):
+        JobsService(None, mock_log, mock_client_session)
+
+
+@pytest.mark.parametrize(
+    "creds, missing_field",
+    [
+        ({"project_id": "p", "region_id": "r"}, "access_token"),
+        ({"access_token": "a", "region_id": "r"}, "project_id"),
+        ({"access_token": "a", "project_id": "p"}, "region_id"),
+    ],
+)
+def test_jobs_service_init_missing_fields(creds, missing_field, mock_log, mock_client_session):
+    with pytest.raises(ValueError, match=f"Missing required credential fields: {missing_field}"):
+        JobsService(creds, mock_log, mock_client_session)
+
+
+def test_jobs_service_create_headers(mock_credentials, mock_log, mock_client_session):
+    service = JobsService(mock_credentials, mock_log, mock_client_session)
+    headers = service.create_headers()
+    assert headers["Authorization"] == "Bearer test-access-token"
+    assert headers["Content-Type"] == "application/json"
+
+
+@pytest.mark.asyncio
+async def test_jobs_service_get_base_url_success(mock_credentials, mock_log, mock_client_session):
+    service = JobsService(mock_credentials, mock_log, mock_client_session)
+    with patch("dataproc_jupyter_plugin.urls.gcp_service_url", new_callable=AsyncMock) as mock_url:
+        mock_url.return_value = "https://dataproc.googleapis.com/"
+        base_url = await service.get_base_url()
+        assert base_url == "https://dataproc.googleapis.com/v1/projects/test-project-123/regions/us-central1/jobs"
+        mock_url.assert_called_once_with(DATAPROC_SERVICE_NAME)
+
+
+@pytest.mark.asyncio
+async def test_jobs_service_get_base_url_error(mock_credentials, mock_log, mock_client_session):
+    service = JobsService(mock_credentials, mock_log, mock_client_session)
+    with patch("dataproc_jupyter_plugin.urls.gcp_service_url", new_callable=AsyncMock) as mock_url:
+        mock_url.side_effect = Exception("Resolution failed")
+        with pytest.raises(RuntimeError, match="Failed to resolve Dataproc service URL"):
+            await service.get_base_url()
+
+
+@pytest.mark.asyncio
+async def test_jobs_service_parse_response_non_json_non_200(mock_credentials, mock_log, mock_client_session):
+    service = JobsService(mock_credentials, mock_log, mock_client_session)
+    mock_resp = AsyncMock()
+    mock_resp.status = 502
+    mock_resp.reason = "Bad Gateway"
+    mock_resp.json.side_effect = aiohttp.ContentTypeError(None, None)
+    mock_resp.text.return_value = "<html>Error</html>"
+
+    result = await service._parse_response(mock_resp, "test_op")
+    assert result == {"error": {"code": 502, "message": "HTTP 502 Bad Gateway: <html>Error</html>"}}
+
+
+@pytest.mark.asyncio
+async def test_jobs_service_parse_response_non_json_200(mock_credentials, mock_log, mock_client_session):
+    service = JobsService(mock_credentials, mock_log, mock_client_session)
+    mock_resp = AsyncMock()
+    mock_resp.status = 200
+    mock_resp.json.side_effect = json.JSONDecodeError("msg", "doc", 0)
+    mock_resp.text.return_value = "Not JSON"
+
+    result = await service._parse_response(mock_resp, "test_op")
+    assert result == {"error": {"code": 500, "message": "Failed to parse server response as JSON during test_op."}}
+
+
+@pytest.mark.asyncio
+async def test_jobs_service_parse_response_exception(mock_credentials, mock_log, mock_client_session):
+    service = JobsService(mock_credentials, mock_log, mock_client_session)
+    mock_resp = AsyncMock()
+    mock_resp.json.side_effect = Exception("Unexpected error")
+
+    result = await service._parse_response(mock_resp, "test_op")
+    assert result == {"error": {"code": 500, "message": "Response processing error during test_op: Unexpected error"}}
+
+
+# =====================================================================
+# Service Unit Tests: Job CRUD Operations (get, update, delete, cancel)
+# =====================================================================
+
+@pytest.mark.asyncio
+async def test_jobs_service_get_job_empty_id(mock_credentials, mock_log, mock_client_session):
+    service = JobsService(mock_credentials, mock_log, mock_client_session)
+    result = await service.get_job("")
+    assert result == {"error": {"code": 400, "message": "Job ID must not be empty."}}
+
+
+@pytest.mark.asyncio
+async def test_jobs_service_get_job_success(mock_credentials, mock_log, mock_client_session):
+    service = JobsService(mock_credentials, mock_log, mock_client_session)
+    mock_resp = AsyncMock()
+    mock_resp.status = 200
+    mock_resp.json.return_value = {"reference": {"jobId": "job-123"}, "status": {"state": "RUNNING"}}
+
+    mock_get_ctx = AsyncMock()
+    mock_get_ctx.__aenter__.return_value = mock_resp
+    mock_client_session.get.return_value = mock_get_ctx
+
+    with patch.object(service, "get_base_url", new_callable=AsyncMock) as mock_base_url:
+        mock_base_url.return_value = "https://dataproc.googleapis.com/v1/jobs"
+        result = await service.get_job("job-123")
+        assert result["reference"]["jobId"] == "job-123"
+        mock_client_session.get.assert_called_once_with(
+            "https://dataproc.googleapis.com/v1/jobs/job-123",
+            headers=service.create_headers(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_jobs_service_get_job_client_error(mock_credentials, mock_log, mock_client_session):
+    service = JobsService(mock_credentials, mock_log, mock_client_session)
+    mock_client_session.get.side_effect = aiohttp.ClientError("Host unreachable")
+
+    with patch.object(service, "get_base_url", new_callable=AsyncMock) as mock_base_url:
+        mock_base_url.return_value = "https://dataproc.googleapis.com/v1/jobs"
+        result = await service.get_job("job-123")
+        assert result == {"error": {"code": 503, "message": "Network error connecting to Dataproc API: Host unreachable"}}
+
+
+@pytest.mark.asyncio
+async def test_jobs_service_get_job_timeout(mock_credentials, mock_log, mock_client_session):
+    service = JobsService(mock_credentials, mock_log, mock_client_session)
+    mock_client_session.get.side_effect = asyncio.TimeoutError()
+
+    with patch.object(service, "get_base_url", new_callable=AsyncMock) as mock_base_url:
+        mock_base_url.return_value = "https://dataproc.googleapis.com/v1/jobs"
+        result = await service.get_job("job-123")
+        assert result == {"error": {"code": 504, "message": "Request to fetch job job-123 timed out."}}
+
+
+@pytest.mark.asyncio
+async def test_jobs_service_get_job_unexpected_error(mock_credentials, mock_log, mock_client_session):
+    service = JobsService(mock_credentials, mock_log, mock_client_session)
+    mock_client_session.get.side_effect = Exception("Crash")
+
+    with patch.object(service, "get_base_url", new_callable=AsyncMock) as mock_base_url:
+        mock_base_url.return_value = "https://dataproc.googleapis.com/v1/jobs"
+        result = await service.get_job("job-123")
+        assert result == {"error": {"code": 500, "message": "Unexpected error fetching job details: Crash"}}
+
+
+@pytest.mark.asyncio
+async def test_jobs_service_update_job_empty_id(mock_credentials, mock_log, mock_client_session):
+    service = JobsService(mock_credentials, mock_log, mock_client_session)
+    result = await service.update_job("", {"job": {}})
+    assert result == {"error": {"code": 400, "message": "Job ID must not be empty."}}
+
+
+@pytest.mark.asyncio
+async def test_jobs_service_update_job_invalid_payload(mock_credentials, mock_log, mock_client_session):
+    service = JobsService(mock_credentials, mock_log, mock_client_session)
+    result = await service.update_job("job-1", None)
+    assert result == {"error": {"code": 400, "message": "Invalid or missing job payload."}}
+
+
+@pytest.mark.asyncio
+async def test_jobs_service_update_job_success(mock_credentials, mock_log, mock_client_session):
+    service = JobsService(mock_credentials, mock_log, mock_client_session)
+    mock_resp = AsyncMock()
+    mock_resp.status = 200
+    mock_resp.json.return_value = {"reference": {"jobId": "job-1"}, "labels": {"key": "val"}}
+
+    mock_patch_ctx = AsyncMock()
+    mock_patch_ctx.__aenter__.return_value = mock_resp
+    mock_client_session.patch.return_value = mock_patch_ctx
+
+    payload = {"labels": {"key": "val"}}
+
+    with patch.object(service, "get_base_url", new_callable=AsyncMock) as mock_base_url:
+        mock_base_url.return_value = "https://dataproc.googleapis.com/v1/jobs"
+        result = await service.update_job("job-1", payload, update_mask="labels")
+        assert result["labels"] == {"key": "val"}
+        mock_client_session.patch.assert_called_once_with(
+            "https://dataproc.googleapis.com/v1/jobs/job-1?updateMask=labels",
+            headers=service.create_headers(),
+            data=json.dumps(payload),
+        )
+
+
+@pytest.mark.asyncio
+async def test_jobs_service_update_job_client_error(mock_credentials, mock_log, mock_client_session):
+    service = JobsService(mock_credentials, mock_log, mock_client_session)
+    mock_client_session.patch.side_effect = aiohttp.ClientError("Patch fail")
+
+    with patch.object(service, "get_base_url", new_callable=AsyncMock) as mock_base_url:
+        mock_base_url.return_value = "https://dataproc.googleapis.com/v1/jobs"
+        result = await service.update_job("job-1", {"job": {}})
+        assert result == {"error": {"code": 503, "message": "Network error updating job: Patch fail"}}
+
+
+@pytest.mark.asyncio
+async def test_jobs_service_update_job_timeout(mock_credentials, mock_log, mock_client_session):
+    service = JobsService(mock_credentials, mock_log, mock_client_session)
+    mock_client_session.patch.side_effect = asyncio.TimeoutError()
+
+    with patch.object(service, "get_base_url", new_callable=AsyncMock) as mock_base_url:
+        mock_base_url.return_value = "https://dataproc.googleapis.com/v1/jobs"
+        result = await service.update_job("job-1", {"job": {}})
+        assert result == {"error": {"code": 504, "message": "Request to update job job-1 timed out."}}
+
+
+@pytest.mark.asyncio
+async def test_jobs_service_update_job_unexpected_error(mock_credentials, mock_log, mock_client_session):
+    service = JobsService(mock_credentials, mock_log, mock_client_session)
+    mock_client_session.patch.side_effect = Exception("Update error")
+
+    with patch.object(service, "get_base_url", new_callable=AsyncMock) as mock_base_url:
+        mock_base_url.return_value = "https://dataproc.googleapis.com/v1/jobs"
+        result = await service.update_job("job-1", {"job": {}})
+        assert result == {"error": {"code": 500, "message": "Unexpected error updating job: Update error"}}
+
+
+@pytest.mark.asyncio
+async def test_jobs_service_delete_job_empty_id(mock_credentials, mock_log, mock_client_session):
+    service = JobsService(mock_credentials, mock_log, mock_client_session)
+    result = await service.delete_job("")
+    assert result == {"error": {"code": 400, "message": "Job ID must not be empty."}}
+
+
+@pytest.mark.asyncio
+async def test_jobs_service_delete_job_success(mock_credentials, mock_log, mock_client_session):
+    service = JobsService(mock_credentials, mock_log, mock_client_session)
+    mock_resp = AsyncMock()
+    mock_resp.status = 200
+    mock_resp.json.return_value = {}
+
+    mock_delete_ctx = AsyncMock()
+    mock_delete_ctx.__aenter__.return_value = mock_resp
+    mock_client_session.delete.return_value = mock_delete_ctx
+
+    with patch.object(service, "get_base_url", new_callable=AsyncMock) as mock_base_url:
+        mock_base_url.return_value = "https://dataproc.googleapis.com/v1/jobs"
+        result = await service.delete_job("job-123")
+        assert result == {}
+        mock_client_session.delete.assert_called_once_with(
+            "https://dataproc.googleapis.com/v1/jobs/job-123",
+            headers=service.create_headers(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_jobs_service_delete_job_client_error(mock_credentials, mock_log, mock_client_session):
+    service = JobsService(mock_credentials, mock_log, mock_client_session)
+    mock_client_session.delete.side_effect = aiohttp.ClientError("Delete error")
+
+    with patch.object(service, "get_base_url", new_callable=AsyncMock) as mock_base_url:
+        mock_base_url.return_value = "https://dataproc.googleapis.com/v1/jobs"
+        result = await service.delete_job("job-123")
+        assert result == {"error": {"code": 503, "message": "Network error deleting job: Delete error"}}
+
+
+@pytest.mark.asyncio
+async def test_jobs_service_delete_job_timeout(mock_credentials, mock_log, mock_client_session):
+    service = JobsService(mock_credentials, mock_log, mock_client_session)
+    mock_client_session.delete.side_effect = asyncio.TimeoutError()
+
+    with patch.object(service, "get_base_url", new_callable=AsyncMock) as mock_base_url:
+        mock_base_url.return_value = "https://dataproc.googleapis.com/v1/jobs"
+        result = await service.delete_job("job-123")
+        assert result == {"error": {"code": 504, "message": "Request to delete job job-123 timed out."}}
+
+
+@pytest.mark.asyncio
+async def test_jobs_service_delete_job_unexpected_error(mock_credentials, mock_log, mock_client_session):
+    service = JobsService(mock_credentials, mock_log, mock_client_session)
+    mock_client_session.delete.side_effect = Exception("Delete fail")
+
+    with patch.object(service, "get_base_url", new_callable=AsyncMock) as mock_base_url:
+        mock_base_url.return_value = "https://dataproc.googleapis.com/v1/jobs"
+        result = await service.delete_job("job-123")
+        assert result == {"error": {"code": 500, "message": "Unexpected error deleting job: Delete fail"}}
+
+
+@pytest.mark.asyncio
+async def test_jobs_service_cancel_job_empty_id(mock_credentials, mock_log, mock_client_session):
+    service = JobsService(mock_credentials, mock_log, mock_client_session)
+    result = await service.cancel_job("")
+    assert result == {"error": {"code": 400, "message": "Job ID must not be empty."}}
+
+
+@pytest.mark.asyncio
+async def test_jobs_service_cancel_job_success(mock_credentials, mock_log, mock_client_session):
+    service = JobsService(mock_credentials, mock_log, mock_client_session)
+    mock_resp = AsyncMock()
+    mock_resp.status = 200
+    mock_resp.json.return_value = {"status": {"state": "CANCELLED"}}
+
+    mock_post_ctx = AsyncMock()
+    mock_post_ctx.__aenter__.return_value = mock_resp
+    mock_client_session.post.return_value = mock_post_ctx
+
+    with patch.object(service, "get_base_url", new_callable=AsyncMock) as mock_base_url:
+        mock_base_url.return_value = "https://dataproc.googleapis.com/v1/jobs"
+        result = await service.cancel_job("job-123")
+        assert result == {"status": {"state": "CANCELLED"}}
+        mock_client_session.post.assert_called_once_with(
+            "https://dataproc.googleapis.com/v1/jobs/job-123:cancel",
+            headers=service.create_headers(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_jobs_service_cancel_job_client_error(mock_credentials, mock_log, mock_client_session):
+    service = JobsService(mock_credentials, mock_log, mock_client_session)
+    mock_client_session.post.side_effect = aiohttp.ClientError("Cancel error")
+
+    with patch.object(service, "get_base_url", new_callable=AsyncMock) as mock_base_url:
+        mock_base_url.return_value = "https://dataproc.googleapis.com/v1/jobs"
+        result = await service.cancel_job("job-123")
+        assert result == {"error": {"code": 503, "message": "Network error canceling job: Cancel error"}}
+
+
+@pytest.mark.asyncio
+async def test_jobs_service_cancel_job_timeout(mock_credentials, mock_log, mock_client_session):
+    service = JobsService(mock_credentials, mock_log, mock_client_session)
+    mock_client_session.post.side_effect = asyncio.TimeoutError()
+
+    with patch.object(service, "get_base_url", new_callable=AsyncMock) as mock_base_url:
+        mock_base_url.return_value = "https://dataproc.googleapis.com/v1/jobs"
+        result = await service.cancel_job("job-123")
+        assert result == {"error": {"code": 504, "message": "Request to cancel job job-123 timed out."}}
+
+
+@pytest.mark.asyncio
+async def test_jobs_service_cancel_job_unexpected_error(mock_credentials, mock_log, mock_client_session):
+    service = JobsService(mock_credentials, mock_log, mock_client_session)
+    mock_client_session.post.side_effect = Exception("Cancel fail")
+
+    with patch.object(service, "get_base_url", new_callable=AsyncMock) as mock_base_url:
+        mock_base_url.return_value = "https://dataproc.googleapis.com/v1/jobs"
+        result = await service.cancel_job("job-123")
+        assert result == {"error": {"code": 500, "message": "Unexpected error canceling job: Cancel fail"}}
+
+
+# =====================================================================
+# Controller Integration Tests: JobItemController & JobCancelController
+# =====================================================================
+
+async def test_job_item_controller_get_missing_job_id(jp_fetch):
+    response = await jp_fetch("dataproc-plugin", "jobItem", method="GET")
+    assert response.code == 200
+    payload = json.loads(response.body)
+    assert payload == {"error": {"code": 400, "message": "Missing required parameter: jobId"}}
+
+
+async def test_job_item_controller_get_success(jp_fetch, monkeypatch):
+    mock_creds = AsyncMock(return_value={"access_token": "token", "project_id": "p", "region_id": "r"})
+    mock_get_job = AsyncMock(return_value={"reference": {"jobId": "job-item-1"}})
+
+    monkeypatch.setattr("dataproc_jupyter_plugin.controllers.jobs.credentials.get_cached", mock_creds)
+    monkeypatch.setattr("dataproc_jupyter_plugin.services.jobs.JobsService.get_job", mock_get_job)
+
+    response = await jp_fetch("dataproc-plugin", "jobItem", method="GET", params={"jobId": "job-item-1"})
+    assert response.code == 200
+    payload = json.loads(response.body)
+    assert payload == {"reference": {"jobId": "job-item-1"}}
+
+
+async def test_job_item_controller_get_value_error(jp_fetch, monkeypatch):
+    mock_creds = AsyncMock(side_effect=ValueError("No creds"))
+    monkeypatch.setattr("dataproc_jupyter_plugin.controllers.jobs.credentials.get_cached", mock_creds)
+
+    response = await jp_fetch("dataproc-plugin", "jobItem", method="GET", params={"jobId": "job-item-1"})
+    assert response.code == 200
+    payload = json.loads(response.body)
+    assert payload == {"error": {"code": 400, "message": "No creds"}}
+
+
+async def test_job_item_controller_get_server_error(jp_fetch, monkeypatch):
+    mock_creds = AsyncMock(side_effect=Exception("GCP down"))
+    monkeypatch.setattr("dataproc_jupyter_plugin.controllers.jobs.credentials.get_cached", mock_creds)
+
+    response = await jp_fetch("dataproc-plugin", "jobItem", method="GET", params={"jobId": "job-item-1"})
+    assert response.code == 200
+    payload = json.loads(response.body)
+    assert payload == {"error": {"code": 500, "message": "Server error: GCP down"}}
+
+
+async def test_job_item_controller_patch_missing_job_id(jp_fetch):
+    response = await jp_fetch("dataproc-plugin", "jobItem", method="PATCH", body=json.dumps({"labels": {}}))
+    assert response.code == 200
+    payload = json.loads(response.body)
+    assert payload == {"error": {"code": 400, "message": "Missing required parameter: jobId"}}
+
+
+async def test_job_item_controller_patch_invalid_json(jp_fetch):
+    response = await jp_fetch("dataproc-plugin", "jobItem", method="PATCH", params={"jobId": "j1"}, body="Bad Json")
+    assert response.code == 200
+    payload = json.loads(response.body)
+    assert payload == {"error": {"code": 400, "message": "Invalid JSON request body."}}
+
+
+async def test_job_item_controller_patch_empty_payload(jp_fetch):
+    response = await jp_fetch("dataproc-plugin", "jobItem", method="PATCH", params={"jobId": "j1"}, body=json.dumps({}))
+    assert response.code == 200
+    payload = json.loads(response.body)
+    assert payload == {"error": {"code": 400, "message": "Missing or empty update payload."}}
+
+
+async def test_job_item_controller_patch_success(jp_fetch, monkeypatch):
+    mock_creds = AsyncMock(return_value={"access_token": "token", "project_id": "p", "region_id": "r"})
+    mock_update_job = AsyncMock(return_value={"reference": {"jobId": "job-item-1"}, "labels": {"env": "prod"}})
+
+    monkeypatch.setattr("dataproc_jupyter_plugin.controllers.jobs.credentials.get_cached", mock_creds)
+    monkeypatch.setattr("dataproc_jupyter_plugin.services.jobs.JobsService.update_job", mock_update_job)
+
+    body = json.dumps({"labels": {"env": "prod"}})
+    response = await jp_fetch("dataproc-plugin", "jobItem", method="PATCH", params={"jobId": "job-item-1"}, body=body)
+    assert response.code == 200
+    payload = json.loads(response.body)
+    assert payload["labels"] == {"env": "prod"}
+
+
+async def test_job_item_controller_patch_value_error(jp_fetch, monkeypatch):
+    mock_creds = AsyncMock(side_effect=ValueError("Invalid auth"))
+    monkeypatch.setattr("dataproc_jupyter_plugin.controllers.jobs.credentials.get_cached", mock_creds)
+
+    body = json.dumps({"labels": {"env": "prod"}})
+    response = await jp_fetch("dataproc-plugin", "jobItem", method="PATCH", params={"jobId": "job-item-1"}, body=body)
+    assert response.code == 200
+    payload = json.loads(response.body)
+    assert payload == {"error": {"code": 400, "message": "Invalid auth"}}
+
+
+async def test_job_item_controller_patch_server_error(jp_fetch, monkeypatch):
+    mock_creds = AsyncMock(side_effect=Exception("Internal error"))
+    monkeypatch.setattr("dataproc_jupyter_plugin.controllers.jobs.credentials.get_cached", mock_creds)
+
+    body = json.dumps({"labels": {"env": "prod"}})
+    response = await jp_fetch("dataproc-plugin", "jobItem", method="PATCH", params={"jobId": "job-item-1"}, body=body)
+    assert response.code == 200
+    payload = json.loads(response.body)
+    assert payload == {"error": {"code": 500, "message": "Server error: Internal error"}}
+
+
+async def test_job_item_controller_delete_missing_job_id(jp_fetch):
+    response = await jp_fetch("dataproc-plugin", "jobItem", method="DELETE")
+    assert response.code == 200
+    payload = json.loads(response.body)
+    assert payload == {"error": {"code": 400, "message": "Missing required parameter: jobId"}}
+
+
+async def test_job_item_controller_delete_success(jp_fetch, monkeypatch):
+    mock_creds = AsyncMock(return_value={"access_token": "token", "project_id": "p", "region_id": "r"})
+    mock_delete_job = AsyncMock(return_value={})
+
+    monkeypatch.setattr("dataproc_jupyter_plugin.controllers.jobs.credentials.get_cached", mock_creds)
+    monkeypatch.setattr("dataproc_jupyter_plugin.services.jobs.JobsService.delete_job", mock_delete_job)
+
+    response = await jp_fetch("dataproc-plugin", "jobItem", method="DELETE", params={"jobId": "job-item-1"})
+    assert response.code == 200
+    payload = json.loads(response.body)
+    assert payload == {}
+
+
+async def test_job_item_controller_delete_value_error(jp_fetch, monkeypatch):
+    mock_creds = AsyncMock(side_effect=ValueError("Creds error"))
+    monkeypatch.setattr("dataproc_jupyter_plugin.controllers.jobs.credentials.get_cached", mock_creds)
+
+    response = await jp_fetch("dataproc-plugin", "jobItem", method="DELETE", params={"jobId": "job-item-1"})
+    assert response.code == 200
+    payload = json.loads(response.body)
+    assert payload == {"error": {"code": 400, "message": "Creds error"}}
+
+
+async def test_job_item_controller_delete_server_error(jp_fetch, monkeypatch):
+    mock_creds = AsyncMock(side_effect=Exception("Delete failure"))
+    monkeypatch.setattr("dataproc_jupyter_plugin.controllers.jobs.credentials.get_cached", mock_creds)
+
+    response = await jp_fetch("dataproc-plugin", "jobItem", method="DELETE", params={"jobId": "job-item-1"})
+    assert response.code == 200
+    payload = json.loads(response.body)
+    assert payload == {"error": {"code": 500, "message": "Server error: Delete failure"}}
+
+
+async def test_job_cancel_controller_post_missing_job_id(jp_fetch):
+    response = await jp_fetch("dataproc-plugin", "jobCancel", method="POST")
+    assert response.code == 200
+    payload = json.loads(response.body)
+    assert payload == {"error": {"code": 400, "message": "Missing required parameter: jobId"}}
+
+
+async def test_job_cancel_controller_post_success(jp_fetch, monkeypatch):
+    mock_creds = AsyncMock(return_value={"access_token": "token", "project_id": "p", "region_id": "r"})
+    mock_cancel_job = AsyncMock(return_value={"status": {"state": "CANCELLED"}})
+
+    monkeypatch.setattr("dataproc_jupyter_plugin.controllers.jobs.credentials.get_cached", mock_creds)
+    monkeypatch.setattr("dataproc_jupyter_plugin.services.jobs.JobsService.cancel_job", mock_cancel_job)
+
+    response = await jp_fetch("dataproc-plugin", "jobCancel", method="POST", params={"jobId": "job-1"})
+    assert response.code == 200
+    payload = json.loads(response.body)
+    assert payload == {"status": {"state": "CANCELLED"}}
+
+
+async def test_job_cancel_controller_post_value_error(jp_fetch, monkeypatch):
+    mock_creds = AsyncMock(side_effect=ValueError("Auth failed"))
+    monkeypatch.setattr("dataproc_jupyter_plugin.controllers.jobs.credentials.get_cached", mock_creds)
+
+    response = await jp_fetch("dataproc-plugin", "jobCancel", method="POST", params={"jobId": "job-1"})
+    assert response.code == 200
+    payload = json.loads(response.body)
+    assert payload == {"error": {"code": 400, "message": "Auth failed"}}
+
+
+async def test_job_cancel_controller_post_server_error(jp_fetch, monkeypatch):
+    mock_creds = AsyncMock(side_effect=Exception("Cancel internal error"))
+    monkeypatch.setattr("dataproc_jupyter_plugin.controllers.jobs.credentials.get_cached", mock_creds)
+
+    response = await jp_fetch("dataproc-plugin", "jobCancel", method="POST", params={"jobId": "job-1"})
+    assert response.code == 200
+    payload = json.loads(response.body)
+    assert payload == {"error": {"code": 500, "message": "Server error: Cancel internal error"}}

--- a/dataproc_jupyter_plugin/tests/test_job.py
+++ b/dataproc_jupyter_plugin/tests/test_job.py
@@ -526,7 +526,7 @@ async def test_job_item_controller_delete_server_error(jp_fetch, monkeypatch):
 
 
 async def test_job_cancel_controller_post_missing_job_id(jp_fetch):
-    response = await jp_fetch("dataproc-plugin", "jobCancel", method="POST")
+    response = await jp_fetch("dataproc-plugin", "jobCancel", method="POST", body="")
     assert response.code == 200
     payload = json.loads(response.body)
     assert payload == {"error": {"code": 400, "message": "Missing required parameter: jobId"}}
@@ -539,7 +539,7 @@ async def test_job_cancel_controller_post_success(jp_fetch, monkeypatch):
     monkeypatch.setattr("dataproc_jupyter_plugin.controllers.jobs.credentials.get_cached", mock_creds)
     monkeypatch.setattr("dataproc_jupyter_plugin.services.jobs.JobsService.cancel_job", mock_cancel_job)
 
-    response = await jp_fetch("dataproc-plugin", "jobCancel", method="POST", params={"jobId": "job-1"})
+    response = await jp_fetch("dataproc-plugin", "jobCancel", method="POST", params={"jobId": "job-1"}, body="")
     assert response.code == 200
     payload = json.loads(response.body)
     assert payload == {"status": {"state": "CANCELLED"}}
@@ -549,7 +549,7 @@ async def test_job_cancel_controller_post_value_error(jp_fetch, monkeypatch):
     mock_creds = AsyncMock(side_effect=ValueError("Auth failed"))
     monkeypatch.setattr("dataproc_jupyter_plugin.controllers.jobs.credentials.get_cached", mock_creds)
 
-    response = await jp_fetch("dataproc-plugin", "jobCancel", method="POST", params={"jobId": "job-1"})
+    response = await jp_fetch("dataproc-plugin", "jobCancel", method="POST", params={"jobId": "job-1"}, body="")
     assert response.code == 200
     payload = json.loads(response.body)
     assert payload == {"error": {"code": 400, "message": "Auth failed"}}
@@ -559,7 +559,7 @@ async def test_job_cancel_controller_post_server_error(jp_fetch, monkeypatch):
     mock_creds = AsyncMock(side_effect=Exception("Cancel internal error"))
     monkeypatch.setattr("dataproc_jupyter_plugin.controllers.jobs.credentials.get_cached", mock_creds)
 
-    response = await jp_fetch("dataproc-plugin", "jobCancel", method="POST", params={"jobId": "job-1"})
+    response = await jp_fetch("dataproc-plugin", "jobCancel", method="POST", params={"jobId": "job-1"}, body="")
     assert response.code == 200
     payload = json.loads(response.body)
     assert payload == {"error": {"code": 500, "message": "Server error: Cancel internal error"}}


### PR DESCRIPTION
- **controllers/jobs.py**: Added `JobItemController` and `JobCancelController`.
- **services/jobs.py**: Implemented backend Dataproc API calls (`get_job`, `update_job`, `delete_job`, `cancel_job`).
- **handlers.py**: Updated `jobItem` and `jobCancel` routes.
- **tests/test_job.py**: Added unit and controller tests.